### PR TITLE
package: emit event when a package is downloading/cached (python3)

### DIFF
--- a/pisi/package.py
+++ b/pisi/package.py
@@ -94,8 +94,13 @@ class Package:
         dest = ctx.config.cached_packages_dir()
         self.filepath = os.path.join(dest, url.filename())
 
+        # So we can emit a notify event with the package info
+        pkg_name, pkg_version = pisi.util.parse_package_name(url.filename())
+        self.metadata, self.files, self.repo = pisi.api.info_name(pkg_name, False)
+
         if not os.path.exists(self.filepath):
             try:
+                ctx.ui.notify(pisi.ui.downloading, package=self.metadata.package, files=self.files)
                 pisi.file.File.download(url, dest)
             except pisi.fetcher.FetchError:
                 # Bug 3465


### PR DESCRIPTION
PiSi currently emits events for other operations e.g. removing,
installing; but crucially not for downloading packages.

This is needed for packagekit so we can get a callback to know when
the package is downloading in order to emit transaction events from
a pisi.api.install call for example.