### PR TITLE
Fix broken pipe on eopkg hs

### DIFF
--- a/pisi/cli/history.py
+++ b/pisi/cli/history.py
@@ -110,7 +110,8 @@ Lists previous operations."""
                     )
 
                 def __del__(self):
-                    self.less.stdin.close()
+                    if self.less.poll() is None:
+                        self.less.stdin.close()
                     self.less.wait()
 
                 def flush(self):


### PR DESCRIPTION
When `less` terminates, modern versions of subprocess close the pipe automatically. This results in a BrokenPipeError if `less` exits before the user reaches EOF.

This PR checks to see if the process is still running before trying to close the pipe, which stops the exception.