### PR TITLE
pxml/xmlfile: Cast to string before writing to stdout

### DIFF
--- a/pisi/pxml/xmlfile.py
+++ b/pisi/pxml/xmlfile.py
@@ -11,6 +11,7 @@
 
  this implementation uses piksemel
 """
+import _io
 
 from lxml import etree as xml
 
@@ -100,6 +101,12 @@ class XmlFile(object):
         finally:
             f.close()
 
-    def writexmlfile(self, file: pisi.file.File):
+    def writexmlfile(self, file: pisi.file.File or _io.TextIOWrapper):
         xml.indent(self.doc)
-        file.write(xml.tostring(self.doc.getroot()))
+        if type(file) is pisi.file.File:
+            file.write(xml.tostring(self.doc.getroot()))
+        elif type(file) is _io.TextIOWrapper:
+            # It looks like all the --xml options probably use this to write to stdout. Can't write bytes to stdout.
+            file.write(xml.tostring(self.doc.getroot()).decode('utf8'))
+        else:
+            raise(TypeError('file must be pisi.file.File, _io.TextIOWrapper'))


### PR DESCRIPTION
Fixes `eopkg info --xml`, for example. Previously, if `writexmlfile` was passed a `pisi.file.File` (per the type hint), it would work. If, however, it was passed (say) `sys,stdout`, like `--xml` output does, you would get a TypeError. 

This PR makes `writexmlfile` cast the output of `xml.tostring()` to a `str` before writing to `file`, if `file` is a `_io.TextIOWrapper` (like sys.stdout).