### PR TITLE
pisi/file: Use compression libraries in text mode

### DIFF
--- a/pisi/file.py
+++ b/pisi/file.py
@@ -224,8 +224,7 @@ class File:
             if ctypes & File.COMPRESSION_TYPE_XZ:
                 compressed_file = self.localfile + ".xz"
                 compressed_files.append(compressed_file)
-                options = {"level": 9}
-                lzma_file = lzma.LZMAFile(compressed_file, "w", options=options)
+                lzma_file = lzma.open(compressed_file, "wt")
                 lzma_file.write(open(self.localfile, "r").read())
                 lzma_file.close()
 

--- a/pisi/file.py
+++ b/pisi/file.py
@@ -231,7 +231,7 @@ class File:
             if ctypes & File.COMPRESSION_TYPE_BZ2:
                 compressed_file = self.localfile + ".bz2"
                 compressed_files.append(compressed_file)
-                bz2.BZ2File(compressed_file, "w").write(
+                bz2.open(compressed_file, "wt").write(
                     open(self.localfile, "r").read()
                 )
 

--- a/pisi/pxml/xmlfile.py
+++ b/pisi/pxml/xmlfile.py
@@ -11,6 +11,7 @@
 
  this implementation uses piksemel
 """
+import _io
 
 from lxml import etree as xml
 
@@ -100,6 +101,12 @@ class XmlFile(object):
         finally:
             f.close()
 
-    def writexmlfile(self, file: pisi.file.File):
+    def writexmlfile(self, file: pisi.file.File or _io.TextIOWrapper):
         xml.indent(self.doc)
-        file.write(xml.tostring(self.doc.getroot()))
+        if type(file) is pisi.file.File:
+            file.write(xml.tostring(self.doc.getroot()))
+        elif type(file) is _io.TextIOWrapper:
+            # It looks like all the --xml options probably use this to write to stdout. Can't write bytes to stdout.
+            file.write(xml.tostring(self.doc.getroot()).decode('utf8'))
+        else:
+            raise(TypeError('file must be pisi.file.File, _io.TextIOWrapper'))


### PR DESCRIPTION
This PR uses lzma and bz2 in text mode rather than binary mode, so they accept the `str` of xml that's being written out. 