### PR TITLE
pisi/operations/build: Make eopkg build work properly

### DIFF
--- a/pisi/actionsapi/shelltools.py
+++ b/pisi/actionsapi/shelltools.py
@@ -288,7 +288,7 @@ def dirName(filePath):
 
 
 def system(command):
-    command = string.join(string.split(command))
+    command = ' '.join(command.split())
     retValue = run_logged(command)
 
     # if return value is different than 0, it means error, raise exception

--- a/pisi/file.py
+++ b/pisi/file.py
@@ -224,8 +224,7 @@ class File:
             if ctypes & File.COMPRESSION_TYPE_XZ:
                 compressed_file = self.localfile + ".xz"
                 compressed_files.append(compressed_file)
-                options = {"level": 9}
-                lzma_file = lzma.LZMAFile(compressed_file, "w", options=options)
+                lzma_file = lzma.open(compressed_file, "wt")
                 lzma_file.write(open(self.localfile, "r").read())
                 lzma_file.close()
 

--- a/pisi/file.py
+++ b/pisi/file.py
@@ -231,7 +231,7 @@ class File:
             if ctypes & File.COMPRESSION_TYPE_BZ2:
                 compressed_file = self.localfile + ".bz2"
                 compressed_files.append(compressed_file)
-                bz2.BZ2File(compressed_file, "w").write(
+                bz2.open(compressed_file, "wt").write(
                     open(self.localfile, "r").read()
                 )
 

--- a/pisi/operations/build.py
+++ b/pisi/operations/build.py
@@ -1359,7 +1359,6 @@ class Builder:
                 else:
                     st = os.lstat(fpath)
 
-                frpath = frpath.decode("latin1").encode("utf-8")
                 d[frpath] = pisi.files.FileInfo(
                     path=frpath,
                     type=ftype,
@@ -1410,10 +1409,9 @@ class Builder:
 
         if code != 0:
             return None
-
-        for line in out.split("\n"):
+        for line in out.split(b"\n"):
             line = line.strip()
-            g = self.r_soname.match(line)
+            g = self.r_soname.match(str(line))
             if g:
                 return g.group(1)
         return None

--- a/pisi/pxml/xmlfile.py
+++ b/pisi/pxml/xmlfile.py
@@ -11,6 +11,7 @@
 
  this implementation uses piksemel
 """
+import _io
 
 from lxml import etree as xml
 
@@ -100,6 +101,12 @@ class XmlFile(object):
         finally:
             f.close()
 
-    def writexmlfile(self, file: pisi.file.File):
+    def writexmlfile(self, file: pisi.file.File or _io.TextIOWrapper):
         xml.indent(self.doc)
-        file.write(xml.tostring(self.doc.getroot()))
+        if type(file) is pisi.file.File:
+            file.write(xml.tostring(self.doc.getroot()))
+        elif type(file) is _io.TextIOWrapper:
+            # It looks like all the --xml options probably use this to write to stdout. Can't write bytes to stdout.
+            file.write(xml.tostring(self.doc.getroot()).decode('utf8'))
+        else:
+            raise(TypeError('file must be pisi.file.File, _io.TextIOWrapper'))


### PR DESCRIPTION
This PR fixes a couple of porting errors which were preventing `eopkg build` from working.