### PR TITLE
pxml/xmlfile: Indent by 4 spaces when writing XML out

### DIFF
--- a/pisi/pxml/xmlfile.py
+++ b/pisi/pxml/xmlfile.py
@@ -96,13 +96,13 @@ class XmlFile(object):
                 compress=compress,
                 sign=sign,
             )
-            xml.indent(self.doc)
+            xml.indent(self.doc, level=4)
             f.write(xml.tostring(self.doc.getroot()))
         finally:
             f.close()
 
     def writexmlfile(self, file: pisi.file.File or _io.TextIOWrapper):
-        xml.indent(self.doc)
+        xml.indent(self.doc, level=4)
         if type(file) is pisi.file.File:
             file.write(xml.tostring(self.doc.getroot()))
         elif type(file) is _io.TextIOWrapper:


### PR DESCRIPTION
This uses an indent level of 4 spaces rather than 2 when formatting XML output such as the index, `--xml` output, and `pspec.xml` from `ypkg`. Piksemel used 4 spaces, while lxml defaults to 2. This change will avoid a lot of noise in the monorepo as packages are rebuild using new tooling.