### PR TITLE
archive.py: Re-encode file_name object to utf-8

### DIFF
--- a/pisi/archive.py
+++ b/pisi/archive.py
@@ -450,8 +450,9 @@ class ArchiveTar(ArchiveBase):
             pass
         self.close()
 
-    def add_to_archive(self, file_name, arc_name=None):
+    def add_to_archive(self, file_name: bytes, arc_name=None):
         """Add file or directory path to the tar archive"""
+
         if not self.tar:
             if self.type == "tar":
                 wmode = "w:"
@@ -475,7 +476,10 @@ class ArchiveTar(ArchiveBase):
             if self.tar is None:
                 self.tar = tarfile.open(self.file_path, wmode, fileobj=self.fileobj)
 
-        self.tar.add(file_name.decode("latin-1"), arc_name)
+        # py3 needs strings encoded to utf-8, so decode the bytestream to latin-1 first
+        # and then re-encode it as an utf-8 string for the tarfile.py py3 library.
+        # This bug was exposed by the usdx package.yml
+        self.tar.add(file_name.decode("latin-1").encode("utf-8"), arc_name)
 
     def close(self):
         self.tar.close()


### PR DESCRIPTION
This is done at the last possible moment before interfacing with the py3 standard library tarfile.py module to keep pisi py3 changes to a minimum.

Lucky for us, it was enough to simply re-encode the decoded-to-latin-1 file_name string to utf-8, which the tarfile.py module can then successfully handle.

The bug was exposed by the usdx package.yml, which includes filenames with umlauts in them that tarfile.py would choke on prior to this commit.

**Test Plan:**

1) clone/update the ypkg.git repo
2) run `./prepare_ypkg_test_venv.sh`
3) check that the venv is active!
4) `git -C ../eopkg/ checkout python3-utf8-filename-decoding`
5) Install needed usdx deps locally with something like:
   `sudo ./ypkg-install-deps ../soluspkgs/packages/u/usdx/package.yml`
6) Test the usdx package build with something like:
   `fakeroot ./ypkg-build ../soluspkgs/packages/u/usdx/package.yml`
7) If usdx builds as expected, remember to do a:
   `sudo eopkg history -t <usdx builddeps install transaction above)>`