### PR TITLE
(py3) Add extended attributes support, from base64 encoded key/value pairs

### DIFF
--- a/pisi/files.py
+++ b/pisi/files.py
@@ -7,6 +7,11 @@ during the build process of a package and used in installation."""
 
 import pisi.pxml.autoxml as autoxml
 
+class ExtendedAttribute(metaclass=autoxml.autoxml):
+    """XAttr holds a key/value mapping of extended attributes """
+
+    a_label = [autoxml.String, autoxml.MANDATORY]
+    s_value = [autoxml.String, autoxml.MANDATORY]
 
 class FileInfo(metaclass=autoxml.autoxml):
     """File holds the information for a File node/tag in files.xml"""
@@ -19,6 +24,7 @@ class FileInfo(metaclass=autoxml.autoxml):
     t_Mode = [autoxml.String, autoxml.OPTIONAL]
     t_Hash = [autoxml.String, autoxml.OPTIONAL, "SHA1Sum"]
     t_Permanent = [autoxml.String, autoxml.OPTIONAL]
+    t_ExtendedAttributes = [[ExtendedAttribute], autoxml.OPTIONAL]
 
     def __str__(self):
         s = "/%s, type: %s, size: %s, sha1sum: %s" % (
@@ -28,7 +34,6 @@ class FileInfo(metaclass=autoxml.autoxml):
             self.hash,
         )
         return s
-
 
 class Files(autoxml.xmlfile.XmlFile, metaclass=autoxml.autoxml):
     tag = "Files"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [{ name = "Solus Project", email = "releng@getsol.us" }]
 keywords = ["package", "manager", "mangement", "solus"]
 classifiers = ["Programming Language :: Python :: 3 :: Only"]
 requires-python = ">=3.8.0"
-dependencies = ["iksemel>=1.6.1", "python-magic>=0.4.27"]
+dependencies = ["iksemel>=1.6.1", "python-magic>=0.4.27", "xattr>= 1.1.0"]
 dynamic = ["version"]
 
 [project.urls]


### PR DESCRIPTION
I re-applied an ancient commit from @ikeycode and ported it to Python 3.

Note that to build this with Nuitka requires that python-xattr (not in the repo yet, I'll do that shortly) is built with xattr/xattr#119 due to python-cffi limitations.