### PR TITLE
Explicitly set pickle.dump protocol to version 2

### DIFF
--- a/pisi/db/lazydb.py
+++ b/pisi/db/lazydb.py
@@ -63,7 +63,7 @@ class LazyDB(Singleton):
                 f.write(LazyDB.cache_version)
                 f.flush()
                 os.fsync(f.fileno())
-            pickle.dump(self._instance, open(self.__cache_file(), "wb"))
+            pickle.dump(self._instance, open(self.__cache_file(), "wb"), protocol=2)
 
     def cache_valid(self):
         try:


### PR DESCRIPTION
This enables python2 pisi to read pickle caches created by python3 eopkg.

**Test Plan**

    sudo ./eopkg-cli --force update-repo
    sudo ./eopkg-cli rdb
    # pickle cache is now created by python3 eopkg with pickle protocol 2
    sudo ./eopkg-cli info pisi
    # verify that python2 eopkg can also read pickle cache
    sudo eopkg-cli info pisi