### PR TITLE
Fix errors in our build system

### DIFF
--- a/eopkg_build.py
+++ b/eopkg_build.py
@@ -21,7 +21,7 @@ MAN_DIR = path(DIST_DIR, "man")
 def source_files():
     files = []
     for root, dirs, filenames in os.walk(PROJECT):
-        files.extend(path(root, f) for f in filenames if (f.endswith(".py") or f.endswith(".py3"))
+        files.extend(path(root, f) for f in filenames if (f.endswith(".py") or f.endswith(".py3")))
     return files
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ uneopkg = "pisi.scripts.uneopkg:main"
 # Builder-specific keys below. We use setuptools.
 
 [build-system]
-requires = ["setuptools>=58.0"]
+requires = ["setuptools>=58.0", "iksemel>=1.6.1", "python-magic>=0.4.27"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
This allows installing eopkg to a venv for testing using `pip install .`