### PR TITLE
Py2: Deterministic install/upgrade order for eopkg & baselayout

### DIFF
--- a/pisi/actionsapi/coreutils.py
+++ b/pisi/actionsapi/coreutils.py
@@ -1,4 +1,4 @@
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005-2010 TUBITAK/UEKAE
 #

--- a/pisi/actionsapi/pisitools.py
+++ b/pisi/actionsapi/pisitools.py
@@ -1,4 +1,4 @@
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005-2010 TUBITAK/UEKAE
 #

--- a/pisi/actionsapi/pisitoolsfunctions.py
+++ b/pisi/actionsapi/pisitoolsfunctions.py
@@ -1,4 +1,4 @@
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005-2010 TUBITAK/UEKAE
 #

--- a/pisi/actionsapi/shelltools.py
+++ b/pisi/actionsapi/shelltools.py
@@ -1,4 +1,4 @@
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005-2010 TUBITAK/UEKAE
 #

--- a/pisi/cli/addrepo.py
+++ b/pisi/cli/addrepo.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005-2011, TUBITAK/UEKAE
 #

--- a/pisi/cli/autoremove.py
+++ b/pisi/cli/autoremove.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005 - 2007, TUBITAK/UEKAE
 # Copyright (C) 2013-2017 Solus Project

--- a/pisi/cli/blame.py
+++ b/pisi/cli/blame.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2009, TUBITAK/UEKAE
 #

--- a/pisi/cli/build.py
+++ b/pisi/cli/build.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005-2011, TUBITAK/UEKAE
 #

--- a/pisi/cli/check.py
+++ b/pisi/cli/check.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005-2011, TUBITAK/UEKAE
 #

--- a/pisi/cli/clean.py
+++ b/pisi/cli/clean.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005 - 2007, TUBITAK/UEKAE
 #

--- a/pisi/cli/command.py
+++ b/pisi/cli/command.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005 - 2007, TUBITAK/UEKAE
 #

--- a/pisi/cli/configurepending.py
+++ b/pisi/cli/configurepending.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005 - 2007, TUBITAK/UEKAE
 #

--- a/pisi/cli/deletecache.py
+++ b/pisi/cli/deletecache.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005 - 2007, TUBITAK/UEKAE
 #

--- a/pisi/cli/delta.py
+++ b/pisi/cli/delta.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005-2011, TUBITAK/UEKAE
 #

--- a/pisi/cli/disablerepo.py
+++ b/pisi/cli/disablerepo.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2009, TUBITAK/UEKAE
 #

--- a/pisi/cli/enablerepo.py
+++ b/pisi/cli/enablerepo.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2009, TUBITAK/UEKAE
 #

--- a/pisi/cli/fetch.py
+++ b/pisi/cli/fetch.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2009, TUBITAK/UEKAE
 #

--- a/pisi/cli/help.py
+++ b/pisi/cli/help.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005 - 2007, TUBITAK/UEKAE
 #

--- a/pisi/cli/history.py
+++ b/pisi/cli/history.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005-2010, TUBITAK/UEKAE
 #

--- a/pisi/cli/index.py
+++ b/pisi/cli/index.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005-2010, TUBITAK/UEKAE
 #

--- a/pisi/cli/info.py
+++ b/pisi/cli/info.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005 - 2007, TUBITAK/UEKAE
 #

--- a/pisi/cli/install.py
+++ b/pisi/cli/install.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005-2010, TUBITAK/UEKAE
 #

--- a/pisi/cli/listavailable.py
+++ b/pisi/cli/listavailable.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005 - 2007, TUBITAK/UEKAE
 #

--- a/pisi/cli/listcomponents.py
+++ b/pisi/cli/listcomponents.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005 - 2007, TUBITAK/UEKAE
 #

--- a/pisi/cli/listinstalled.py
+++ b/pisi/cli/listinstalled.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005-2010, TUBITAK/UEKAE
 #

--- a/pisi/cli/listnewest.py
+++ b/pisi/cli/listnewest.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2009, TUBITAK/UEKAE
 #

--- a/pisi/cli/listpending.py
+++ b/pisi/cli/listpending.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005 - 2007, TUBITAK/UEKAE
 #

--- a/pisi/cli/listrepo.py
+++ b/pisi/cli/listrepo.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005 - 2007, TUBITAK/UEKAE
 #

--- a/pisi/cli/listupgrades.py
+++ b/pisi/cli/listupgrades.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005-2010, TUBITAK/UEKAE
 #

--- a/pisi/cli/rebuilddb.py
+++ b/pisi/cli/rebuilddb.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005 - 2007, TUBITAK/UEKAE
 #

--- a/pisi/cli/remove.py
+++ b/pisi/cli/remove.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005 - 2007, TUBITAK/UEKAE
 #

--- a/pisi/cli/removeorphans.py
+++ b/pisi/cli/removeorphans.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005 - 2007, TUBITAK/UEKAE
 #

--- a/pisi/cli/removerepo.py
+++ b/pisi/cli/removerepo.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005 - 2007, TUBITAK/UEKAE
 #

--- a/pisi/cli/search.py
+++ b/pisi/cli/search.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005 - 2007, TUBITAK/UEKAE
 #

--- a/pisi/cli/searchfile.py
+++ b/pisi/cli/searchfile.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005 - 2007, TUBITAK/UEKAE
 #

--- a/pisi/cli/updaterepo.py
+++ b/pisi/cli/updaterepo.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005 - 2007, TUBITAK/UEKAE
 #

--- a/pisi/cli/upgrade.py
+++ b/pisi/cli/upgrade.py
@@ -1,4 +1,4 @@
-# -*- coding:utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2005-2010, TUBITAK/UEKAE
 #

--- a/pisi/operations/helper.py
+++ b/pisi/operations/helper.py
@@ -12,6 +12,7 @@
 
 import os
 
+from ordered_set import OrderedSet as set
 from pisi import translate as _
 
 import pisi
@@ -35,8 +36,11 @@ def reorder_base_packages(order):
             systembase_order.append(pkg)
         else:
             nonbase_order.append(pkg)
-
-    return systembase_order + nonbase_order
+    install_order = systembase_order + nonbase_order
+    ctx.ui.warning(_("Reordering install order so system.base packages come first."))
+    if len(install_order) > 1 and ctx.config.get_option("debug"):
+        ctx.ui.info(_("install_order: %s" % install_order))
+    return install_order
 
 def check_conflicts(order, packagedb):
     """check if upgrading to the latest versions will cause havoc

--- a/pisi/operations/history.py
+++ b/pisi/operations/history.py
@@ -14,6 +14,8 @@ import gettext
 __trans = gettext.translation("pisi", fallback=True)
 _ = __trans.ugettext
 
+from ordered_set import OrderedSet as set
+
 import pisi
 import pisi.context as ctx
 import pisi.util

--- a/pisi/operations/install.py
+++ b/pisi/operations/install.py
@@ -14,6 +14,7 @@ import os
 import sys
 import zipfile
 
+from ordered_set import OrderedSet as set
 from pisi import translate as _
 
 import pisi
@@ -24,6 +25,32 @@ import pisi.operations as operations
 import pisi.pgraph as pgraph
 import pisi.ui as ui
 import pisi.db
+
+BASELAYOUT_PKG = 'baselayout'
+EOPKG_PKG = 'eopkg'
+
+def plan_deterministic_install_order(order):
+    """Ensure that baselayout and eopkg are put at the end of any topological sort that includes them."""
+
+    # save cycles
+    if len(order) <= 1:
+        return order
+
+    # when eopkg is in the order, move it to the end of the order (since the order gets reversed).
+    # this is useful when file ownership between it and pisi changes.
+    if EOPKG_PKG in order:
+        order.remove(EOPKG_PKG)
+        order.append(EOPKG_PKG)
+        # An alternative is to _force_ eopkg to be upgraded/installed by itself, such that the next
+        # operation is guaranteed to be using the new eopkg version. This option needs to stay on the table.
+        #return [EOPKG_PKG]
+
+    # always order baselayout _last_ (since the order gets reversed)
+    if BASELAYOUT_PKG in order:
+        order.remove(BASELAYOUT_PKG)
+        order.append(BASELAYOUT_PKG)
+
+    return order
 
 def install_pkg_names(A, reinstall = False):
     """This is the real thing. It installs packages from
@@ -247,6 +274,7 @@ def install_pkg_files(package_URIs, reinstall = False):
         conflicts = operations.helper.check_conflicts(order, packagedb)
         if conflicts:
             operations.remove.remove_conflicting_packages(conflicts)
+    order = plan_deterministic_install_order(order)
     order.reverse()
     ctx.ui.info(_('Installation order: ') + util.strlist(order) )
 
@@ -312,5 +340,12 @@ def plan_install_pkg_names(A):
     if ctx.config.get_option('debug'):
         G_f.write_graphviz(sys.stdout)
     order = G_f.topological_sort()
+    if len(order) > 1 and ctx.config.get_option("debug"):
+        ctx.ui.info(_("topological_sort order: %s" % order))
+    order = plan_deterministic_install_order(order)
+    if len(order) > 1 and ctx.config.get_option("debug"):
+        ctx.ui.info(_("deterministic order: %s" % order))
     order.reverse()
+    if len(order) > 1 and ctx.config.get_option("debug"):
+        ctx.ui.info(_("final order.reverse(): %s" % order))
     return G_f, order

--- a/pisi/operations/upgrade.py
+++ b/pisi/operations/upgrade.py
@@ -12,6 +12,7 @@
 
 import sys
 
+from ordered_set import OrderedSet as set
 from pisi import translate as _
 
 import pisi
@@ -334,6 +335,7 @@ def plan_upgrade(A, force_replaced=True, replaces=None):
         G_f.write_graphviz(sys.stdout)
 
     order = G_f.topological_sort()
+    order = operations.install.plan_deterministic_install_order(order)
     order.reverse()
     return G_f, order
 
@@ -366,8 +368,14 @@ def upgrade_base(A = set()):
                                  "following packages:"))
                 ctx.ui.info(util.format_by_columns(sorted(extra_upgrades)))
                 G_f, upgrade_order = plan_upgrade(extra_upgrades, force_replaced=False)
+            install_and_upgrade_order = set(install_order + upgrade_order)
+            if len(install_and_upgrade_order) > 1 and ctx.config.get_option("debug"):
+                ctx.ui.info(_("installs and upgrades (unordered): %s" % install_and_upgrade_order))
+            install_and_upgrade_order = operations.install.plan_deterministic_install_order(install_and_upgrade_order)
+            if len(install_and_upgrade_order) > 1 and ctx.config.get_option("debug"):
+                ctx.ui.info(_("installs and upgrades (deterministic order): %s" % install_and_upgrade_order))
             # return packages that must be added to any installation
-            return set(install_order + upgrade_order)
+            return install_and_upgrade_order
         else:
             ctx.ui.warning(_('Safety switch: The component system.base cannot be found.'))
     return set()

--- a/pisi/scenarioapi/package.py
+++ b/pisi/scenarioapi/package.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python2
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2006, TUBITAK/UEKAE
 #

--- a/pisi/scenarioapi/pisiops.py
+++ b/pisi/scenarioapi/pisiops.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python2
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2006, TUBITAK/UEKAE
 #

--- a/pisi/scenarioapi/repoops.py
+++ b/pisi/scenarioapi/repoops.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python2
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2006, TUBITAK/UEKAE
 #

--- a/pisi/scenarioapi/scenario.py
+++ b/pisi/scenarioapi/scenario.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python2
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2006, TUBITAK/UEKAE
 #

--- a/pisi/scenarioapi/withops.py
+++ b/pisi/scenarioapi/withops.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python2
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2006, TUBITAK/UEKAE
 #

--- a/pisi/urlcheck.py
+++ b/pisi/urlcheck.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import pisi.context as ctx
 
 def switch_from_legacy(repo_url):

--- a/scenarios/run.py
+++ b/scenarios/run.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python2
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2006, TUBITAK/UEKAE
 #


### PR DESCRIPTION
This will ensure that future upgrades to eopkg and baselayout will always happen in a (semi-)deterministic fashion.

- If eopkg is part of the install or upgrade transaction, eopkg will be moved to the front of the transaction.
- If baselayout is part of the install or upgrade transaction, baselayout will be moved to the front of the transaction (possibly in front of eopkg).

For context, only the ordering between eopkg, baselayout and any system.base packages which are part of the transaction is currently preserved.

The install order in the presence of system.base packages can potentially also be tweaked now that we're using ordered sets where it matters (if people are not happy with the current logic).

Note that this commit requires you to build and install the [python2-ordered-set PR](https://github.com/getsolus/packages/pull/3057) that @sheepman4267 prepared.

**How to use this branch as a daily driver for testing**

- (git clone the eopkg repo somewhere) / `git pull -a`
- `git checkout py2-eopkg-and-baselayout-install-upgrade-order`
- Add the following function (or its equivalent) to your shell startup scripts:
```bash
function eopkg () {
    pushd ~/repos/getsolus/pisi-py2/ # replace with your own location!
    # if the invocation does not exit 0, still return to the previous location
    sudo ./eopkg.py2 --debug ${*} || :
    popd
}
```

**Test case**

This test case consistently reinstalls baselayout, pisi and eopkg first (in that order). Any other packages may arrive in whatever order the topological sort used by pisi determines is valid (it is not stable).

```
ermo@solbox:~/repos/getsolus/pisi-py2 [py2-eopkg-and-baselayout-install-upgrade-order* +1 ~0 -0 !]
$ sudo ./eopkg.py2 --debug it --reinstall baselayout eopkg pisi htop solbuild nano
DEBUG: InstallDB initialized in 0.00686407089233.
DEBUG: PackageDB initialized in 0.0629091262817.
DEBUG: RepoDB initialized in 0.000216007232666.
DEBUG: HistoryDB initialized in 0.0993731021881.
DEBUG: ComponentDB initialized in 0.00314283370972.
DEBUG: RepoDB initialized in 7.29560852051e-05.
DEBUG: InstallDB initialized in 0.00521898269653.
DEBUG: PackageDB initialized in 0.0601711273193.
digraph G {


}
DEBUG: checking glibc release >= 114
DEBUG: checking python
DEBUG: checking python2-xattr
DEBUG: checking db5
DEBUG: checking piksemel
DEBUG: checking usysconf
DEBUG: checking ncurses release >= 21
DEBUG: checking libcap2 release >= 15
DEBUG: checking glibc release >= 98
DEBUG: checking lm_sensors
DEBUG: checking glibc release >= 114
DEBUG: checking git
DEBUG: checking file release >= 24
DEBUG: checking glibc release >= 110
DEBUG: checking ncurses release >= 25
DEBUG: checking nanorc
digraph G {
pisi[ label = "pisi(3.11,111)" ];
nano[ label = "nano(8.0,195)" ];
eopkg[ label = "eopkg(4.0.0,6)" ];
htop[ label = "htop(3.3.0,22)" ];
solbuild[ label = "solbuild(1.6.3,54)" ];
baselayout[ label = "baselayout(1.9.0,76)" ];


}
topological_sort order: ['baselayout', 'solbuild', 'htop', 'eopkg', 'nano', 'pisi']
deterministic order: ['solbuild', 'htop', 'nano', 'pisi', 'eopkg', 'baselayout']
final order.reverse(): ['baselayout', 'eopkg', 'pisi', 'nano', 'htop', 'solbuild']
Reordering install order so system.base packages come first.
install_order: ['baselayout', 'pisi', 'eopkg', 'nano', 'htop', 'solbuild']
Following packages will be installed:
baselayout  eopkg  htop  nano  pisi  solbuild
Total size of package(s): 22.10 MB
Downloading 1 / 6
Package baselayout found in repository Unstable
baselayout-1.9.0-76-1-x86_64.eopkg [cached]
Downloading 2 / 6
Package pisi found in repository Unstable
pisi-3.11-111-1-x86_64.eopkg [cached]
Downloading 3 / 6
Package eopkg found in repository Unstable
eopkg-4.0.0-6-1-x86_64.eopkg [cached]
Downloading 4 / 6
Package nano found in repository Unstable
nano-8.0-195-1-x86_64.eopkg [cached]
Downloading 5 / 6
Package htop found in repository Unstable
htop-3.3.0-22-1-x86_64.eopkg [cached]
Downloading 6 / 6
Package solbuild found in repository Unstable
solbuild-1.6.3-54-1-x86_64.eopkg [cached]
Installing 1 / 6
baselayout-1.9.0-76-1-x86_64.eopkg [cached]
Installing baselayout, version 1.9.0, release 76
DEBUG: FilesDB initialized in 0.00332593917847.
Extracting the files of baselayout
Installed baselayout
Installing 2 / 6
pisi-3.11-111-1-x86_64.eopkg [cached]
Installing pisi, version 3.11, release 111
Extracting the files of pisi
Installed pisi
Installing 3 / 6
eopkg-4.0.0-6-1-x86_64.eopkg [cached]
Installing eopkg, version 4.0.0, release 6
Extracting the files of eopkg
Installed eopkg
Installing 4 / 6
nano-8.0-195-1-x86_64.eopkg [cached]
Installing nano, version 8.0, release 195
Extracting the files of nano
Installed nano
Installing 5 / 6
htop-3.3.0-22-1-x86_64.eopkg [cached]
Installing htop, version 3.3.0, release 22
Extracting the files of htop
Installed htop
Installing 6 / 6
solbuild-1.6.3-54-1-x86_64.eopkg [cached]
Installing solbuild, version 1.6.3, release 54
Extracting the files of solbuild
Installed solbuild
 [✓] Syncing filesystems                                                success
 [✓] Updating dynamic library cache                                     success
 [✓] Updating systemd tmpfiles                                          success
 [✓] Updating icon theme cache: hicolor                                 success
 [✓] Updating desktop database                                          success
 [✓] Updating manpages database                                         success
ermo@solbox:~/repos/getsolus/pisi-py2 [py2-eopkg-and-baselayout-install-upgrade-order* +1 ~0 -0 !]
$ 
```