### PR TITLE
Py3: Deterministic install/upgrade order for eopkg & baselayout

### DIFF
--- a/pisi/operations/helper.py
+++ b/pisi/operations/helper.py
@@ -3,6 +3,7 @@
 
 import os
 
+from ordered_set import OrderedSet as set
 from pisi import translate as _
 
 import pisi
@@ -27,7 +28,11 @@ def reorder_base_packages(order):
         else:
             nonbase_order.append(pkg)
 
-    return systembase_order + nonbase_order
+    install_order = systembase_order + nonbase_order
+    ctx.ui.warning(_("Reordering install order so system.base packages come first."))
+    if len(install_order) > 1 and ctx.config.get_option("debug"):
+        ctx.ui.info(_("install_order: %s" % install_order))
+    return install_order
 
 
 def check_conflicts(order, packagedb):

--- a/pisi/operations/history.py
+++ b/pisi/operations/history.py
@@ -7,6 +7,8 @@ import gettext
 __trans = gettext.translation("pisi", fallback=True)
 _ = __trans.gettext
 
+from ordered_set import OrderedSet as set
+
 import pisi
 import pisi.context as ctx
 import pisi.util


### PR DESCRIPTION
This will ensure that future upgrades to eopkg and baselayout will always happen in a (semi-)deterministic fashion.

- If eopkg is part of the install or upgrade transaction, eopkg will be moved to the front of the transaction.
- If baselayout is part of the install or upgrade transaction, baselayout will be moved to the front of the transaction (possibly in front of eopkg).

For context, only the ordering between eopkg, baselayout and any system.base packages which are part of the transaction is currently preserved.

**How to use this branch as a daily driver for testing**

- (git clone the eopkg repo somewhere) / `git pull -a`
- `git checkout py3-eopkg-and-baselayout-install-upgrade-order
- Add the following function (or its equivalent) to your shell startup scripts:

```bash
function eopkg () {
    pushd ~/repos/getsolus/eopkg-py3/ # replace with your own location!
    # if the invocation does not exit 0, still return to the previous location
    sudo ./eopkg.py3 --debug ${*} || :
    popd
}
```

The install order in the presence of system.base packages can potentially also be tweaked now that we're using ordered sets where it matters (if people are not happy with the current logic).

Note that this commit requires you to install the python-ordered-sets package.

**Test case**

This test case consistently reinstalls baselayout, pisi and eopkg first (in that order). Any other packages may arrive in whatever order the topological sort used by pisi determines is valid (it is not stable).

```
ermo@solbox:~/repos/getsolus/eopkg4-py3 [py3-eopkg-and-baselayout-install-upgrade-order ψ]
$ sudo ./eopkg.py3 --debug it --reinstall solbuild eopkg pisi baselayout htop nano
DEBUG: InstallDB initialized in 0.004728078842163086.
DEBUG: PackageDB initialized in 0.18265271186828613.
DEBUG: RepoDB initialized in 0.00025534629821777344.
DEBUG: HistoryDB initialized in 0.008744239807128906.
DEBUG: ComponentDB initialized in 0.0019195079803466797.
DEBUG: RepoDB initialized in 6.413459777832031e-05.
DEBUG: InstallDB initialized in 0.0032660961151123047.
DEBUG: PackageDB initialized in 0.1510472297668457.
digraph G {


}
DEBUG: checking glibc release >= 114
DEBUG: checking git
DEBUG: checking glibc release >= 114
DEBUG: checking python
DEBUG: checking python2-xattr
DEBUG: checking db5
DEBUG: checking piksemel
DEBUG: checking usysconf
DEBUG: checking ncurses release >= 21
DEBUG: checking libcap2 release >= 15
DEBUG: checking glibc release >= 98
DEBUG: checking lm_sensors
DEBUG: checking file release >= 24
DEBUG: checking glibc release >= 110
DEBUG: checking ncurses release >= 25
DEBUG: checking nanorc
digraph G {
solbuild[ label = "solbuild(1.6.3,54)" ];
eopkg[ label = "eopkg(4.0.0,6)" ];
pisi[ label = "pisi(3.11,111)" ];
nano[ label = "nano(8.0,195)" ];
baselayout[ label = "baselayout(1.9.0,76)" ];
htop[ label = "htop(3.3.0,22)" ];


}
topological_sort() order: ['htop', 'baselayout', 'nano', 'pisi', 'eopkg', 'solbuild']
deterministic order: ['htop', 'nano', 'pisi', 'solbuild', 'eopkg', 'baselayout']
final order.reverse(): ['baselayout', 'eopkg', 'solbuild', 'pisi', 'nano', 'htop']
Reordering install order so system.base packages come first.
install_order: ['baselayout', 'pisi', 'eopkg', 'solbuild', 'nano', 'htop']
Following packages will be installed:
baselayout  eopkg  htop  nano  pisi  solbuild
Total size of package(s): 22.10 MB
Downloading 1 / 6
Package baselayout found in repository Unstable
baselayout-1.9.0-76-1-x86_64.eopkg [cached]
Downloading 2 / 6
Package pisi found in repository Unstable
pisi-3.11-111-1-x86_64.eopkg [cached]
Downloading 3 / 6
Package eopkg found in repository Unstable
eopkg-4.0.0-6-1-x86_64.eopkg [cached]
Downloading 4 / 6
Package solbuild found in repository Unstable
solbuild-1.6.3-54-1-x86_64.eopkg [cached]
Downloading 5 / 6
Package nano found in repository Unstable
nano-8.0-195-1-x86_64.eopkg [cached]
Downloading 6 / 6
Package htop found in repository Unstable
htop-3.3.0-22-1-x86_64.eopkg [cached]
Installing 1 / 6
baselayout-1.9.0-76-1-x86_64.eopkg [cached]
Installing baselayout, version 1.9.0, release 76
DEBUG: FilesDB initialized in 4.363059997558594e-05.
Extracting the files of baselayout
Installed baselayout
Installing 2 / 6
pisi-3.11-111-1-x86_64.eopkg [cached]
Installing pisi, version 3.11, release 111
Extracting the files of pisi
Installed pisi
Installing 3 / 6
eopkg-4.0.0-6-1-x86_64.eopkg [cached]
Installing eopkg, version 4.0.0, release 6
Extracting the files of eopkg
Installed eopkg
Installing 4 / 6
solbuild-1.6.3-54-1-x86_64.eopkg [cached]
Installing solbuild, version 1.6.3, release 54
Extracting the files of solbuild
Installed solbuild
Installing 5 / 6
nano-8.0-195-1-x86_64.eopkg [cached]
Installing nano, version 8.0, release 195
Extracting the files of nano
Installed nano
Installing 6 / 6
htop-3.3.0-22-1-x86_64.eopkg [cached]
Installing htop, version 3.3.0, release 22
Extracting the files of htop
Installed htop
 [✓] Syncing filesystems                                                success
 [✓] Updating dynamic library cache                                     success
 [✓] Updating systemd tmpfiles                                          success
 [✓] Updating icon theme cache: hicolor                                 success
 [✓] Updating desktop database                                          success
 [✓] Updating manpages database                                         success
ermo@solbox:~/repos/getsolus/eopkg4-py3 [py3-eopkg-and-baselayout-install-upgrade-order ψ]
$ 
```