### PR TITLE
pisi: Bump version to v3.12.1

### DIFF
--- a/pisi/__init__.py
+++ b/pisi/__init__.py
@@ -29,7 +29,7 @@ except:
     def translate(msg): return msg
 
 
-__version__ = "3.11"
+__version__ = "3.12.1"
 
 __all__ = [ 'api', 'configfile', 'db']
 


### PR DESCRIPTION
... because I forgot to bump to v3.12 for the v3.12 release. ._.