### PR TITLE
eopkg: Bump version to v4.1.1

### DIFF
--- a/pisi/__init__.py
+++ b/pisi/__init__.py
@@ -32,7 +32,7 @@ except:
         return msg
 
 
-__version__ = "4.0.0"
+__version__ = "4.1.1"
 
 __all__ = ["api", "configfile", "db"]
 


### PR DESCRIPTION
... because I forgot to bump to v4.1.0 for the v4.1.0 release. ._.