### PR TITLE
Stop putting system.base at the front of the order

### DIFF
--- a/build_chroot.sh
+++ b/build_chroot.sh
@@ -133,8 +133,8 @@ basicSetup () {
     local chroot="sudo systemd-nspawn --as-pid2 --quiet -D ${SOLROOT}" # better chroot essentially
     #local chroot="sudo chroot ${SOLROOT}"
     # necessary cruft for sudo to work with the eopkg_venv
-    local eopkg_py3="sudo -E env PATH=${PATH} eopkg.py3"
-    local eopkg_bin='eopkg.bin'
+    local eopkg_py3="sudo -E env PATH=${PATH} eopkg.py3 --debug"
+    local eopkg_bin='eopkg.bin --debug'
     local mkdir='sudo mkdir -pv'
 
     local eopkg_py3_path="$(command -v eopkg.py3)"
@@ -171,6 +171,9 @@ basicSetup () {
     printInfo "${MSG}"
     ${eopkg_py3} remove-repo Solus -D "${SOLROOT}" || die "${MSG}"
 
+    MSG="Listing enabled repositories ..."
+    printInfo "${MSG}"
+    ${eopkg_py3} list-repo -D "${SOLROOT}" || die "${MSG}"
     #MSG="Installing baselayout ..."
     #${eopkg_py3} install -y -D "${SOLROOT}" --ignore-safety --ignore-comar baselayout || die "${MSG}"
 

--- a/eopkg_venv_functions.bash
+++ b/eopkg_venv_functions.bash
@@ -6,6 +6,9 @@ set -euo pipefail
 
 source shared_functions.bash
 
+# allow user to override branch name
+EOPKG_BRANCH="${BRANCH:-main}"
+
 function prepare_venv () {
     if [[ -z "${PY3}" ]]; then
         die "Couldn't find supported python3 (3.11 || 3.12 || 3.10) interpreter, exiting!"
@@ -15,7 +18,7 @@ function prepare_venv () {
     # Assume the user starts in the eopkg dir
     printInfo "Updating the eopkg git repo ..."
     # ensure we show the current branch
-    git fetch && git checkout main && git pull && git branch
+    git fetch && git checkout "${EOPKG_BRANCH}" && git pull && git branch
 
     printInfo "Set up a clean eopkg_venv venv ..."
     ${PY3} -m venv --system-site-packages --clear eopkg_venv

--- a/pisi/operations/helper.py
+++ b/pisi/operations/helper.py
@@ -14,7 +14,7 @@ import pisi.conflict
 import pisi.db
 
 
-def reorder_base_packages(order):
+def reorder_base_packages_old(order):
     componentdb = pisi.db.componentdb.ComponentDB()
 
     """system.base packages must be first in order"""
@@ -34,6 +34,18 @@ def reorder_base_packages(order):
         ctx.ui.info(_("install_order: %s" % install_order))
     return install_order
 
+def reorder_base_packages(order):
+    """Dummy function that doesn't actually re-order system.base in front.
+
+       We now use OrderedSets, which keep the original topological sort,
+       so this shouldn't actually be necessary now.
+
+       This also implies that the only function of system.base is for the
+       packages in it to be un-removable.
+    """
+    if len(order) > 1 and ctx.config.get_option("debug"):
+        ctx.ui.info(_("order: %s" % order))
+    return order
 
 def check_conflicts(order, packagedb):
     """check if upgrading to the latest versions will cause havoc


### PR DESCRIPTION
We now use OrderedSets, which keep the original topological sort, so this shouldn't actually be necessary now.

This also implies that the only function of system.base is for the packages in it to be un-removable.

NB: This change is _experimental_ and will need loads of upgrade testing!