### PR TITLE
pisi: Stop re-ordering eopkg for installs/upgrades

### DIFF
--- a/pisi/__init__.py
+++ b/pisi/__init__.py
@@ -29,7 +29,7 @@ except:
     def translate(msg): return msg
 
 
-__version__ = "3.12.1"
+__version__ = "3.12.2"
 
 __all__ = [ 'api', 'configfile', 'db']
 

--- a/pisi/operations/helper.py
+++ b/pisi/operations/helper.py
@@ -37,10 +37,25 @@ def reorder_base_packages(order):
         else:
             nonbase_order.append(pkg)
     install_order = systembase_order + nonbase_order
-    ctx.ui.warning(_("Reordering install order so system.base packages come first."))
+    # this is a cheat; the code runs regardless currently
+    if not ctx.config.values.general.ignore_safety and not ctx.get_option('ignore_safety'):
+        ctx.ui.warning(_("Reordering install order so system.base packages come first."))
     if len(install_order) > 1 and ctx.config.get_option("debug"):
         ctx.ui.info(_("install_order: %s" % install_order))
     return install_order
+
+def reorder_base_packages_dummy(order):
+    """Dummy function that doesn't actually re-order system.base in front.
+
+       We now use OrderedSets, which keep the original topological sort,
+       so this shouldn't actually be necessary now.
+
+       This also implies that the only function of system.base is for the
+       packages in it to be un-removable.
+    """
+    if len(order) > 1 and ctx.config.get_option("debug"):
+        ctx.ui.info(_("install_order including any system.base deps: %s" % order))
+    return order
 
 def check_conflicts(order, packagedb):
     """check if upgrading to the latest versions will cause havoc

--- a/pisi/operations/upgrade.py
+++ b/pisi/operations/upgrade.py
@@ -335,7 +335,7 @@ def plan_upgrade(A, force_replaced=True, replaces=None):
         G_f.write_graphviz(sys.stdout)
 
     order = G_f.topological_sort()
-    order = operations.install.plan_deterministic_install_order(order)
+    order = operations.install.reorder_baselayout(order)
     order.reverse()
     return G_f, order
 
@@ -371,9 +371,9 @@ def upgrade_base(A = set()):
             install_and_upgrade_order = set(install_order + upgrade_order)
             if len(install_and_upgrade_order) > 1 and ctx.config.get_option("debug"):
                 ctx.ui.info(_("installs and upgrades (unordered): %s" % install_and_upgrade_order))
-            install_and_upgrade_order = operations.install.plan_deterministic_install_order(install_and_upgrade_order)
+            install_and_upgrade_order = operations.install.reorder_baselayout(install_and_upgrade_order)
             if len(install_and_upgrade_order) > 1 and ctx.config.get_option("debug"):
-                ctx.ui.info(_("installs and upgrades (deterministic order): %s" % install_and_upgrade_order))
+                ctx.ui.info(_("installs and upgrades (baselayout last): %s" % install_and_upgrade_order))
             # return packages that must be added to any installation
             return install_and_upgrade_order
         else:


### PR DESCRIPTION
With this change, eopkg being in the upgrade order with an associated glibc update will no longer force pisi to abort the transaction due to eopkg showing unfilled dependencies.