### PR TITLE
Add handling for usr merged paths

### DIFF
--- a/pisi/archive.py
+++ b/pisi/archive.py
@@ -281,8 +281,10 @@ class ArchiveTar(ArchiveBase):
         print(("Overwriting stale pip install: /{}".format(info.name)))
         shutil.rmtree(info.name)
 
-    def unpack_dir(self, target_dir, callback=None):
-        files = self._tar_file_list()
+    def unpack_dir(self, target_dir, callback=None, files=None):
+        if files is None:
+            files = self._tar_file_list()
+
         self.tar = self._open_tar()
 
         oldwd = None

--- a/pisi/archive.py
+++ b/pisi/archive.py
@@ -13,6 +13,7 @@ import zipfile
 import lzma
 
 from pisi import translate as _
+from pisi.usr_merge import is_usr_merged_duplicate
 
 # eopkg modules
 import pisi
@@ -281,21 +282,8 @@ class ArchiveTar(ArchiveBase):
         shutil.rmtree(info.name)
 
     def unpack_dir(self, target_dir, callback=None):
-        rmode = ""
-        self.tar = None
-        if self.type == "tar":
-            rmode = "r:"
-        elif self.type == "targz":
-            rmode = "r:gz"
-        elif self.type == "tarbz2":
-            rmode = "r:bz2"
-        elif self.type in ("tarlzma", "tarxz"):
-            self.tar = TarFile.lzmaopen(self.file_path, fileobj=self.fileobj)
-        else:
-            raise UnknownArchiveType
-
-        if self.tar is None:
-            self.tar = tarfile.open(self.file_path, rmode, fileobj=self.fileobj)
+        files = self._tar_file_list()
+        self.tar = self._open_tar()
 
         oldwd = None
         try:
@@ -309,6 +297,10 @@ class ArchiveTar(ArchiveBase):
         gid = os.getgid()
 
         for tarinfo in self.tar:
+            if is_usr_merged_duplicate(files, tarinfo.path):
+                ctx.ui.debug("Skipping merged file %s" % tarinfo.path)
+                continue
+
             if callback:
                 callback(tarinfo, extracted=False)
 
@@ -480,6 +472,28 @@ class ArchiveTar(ArchiveBase):
     def close(self):
         self.tar.close()
 
+    def _open_tar(self):
+        if self.type == "tar":
+            rmode = "r:"
+        elif self.type == "targz":
+            rmode = "r:gz"
+        elif self.type == "tarbz2":
+            rmode = "r:bz2"
+        elif self.type in ("tarlzma", "tarxz"):
+            return TarFile.lzmaopen(self.file_path, fileobj=self.fileobj)
+        else:
+            raise UnknownArchiveType
+
+        return tarfile.open(self.file_path, rmode, fileobj=self.fileobj)
+
+    def _tar_file_list(self):
+        with self._open_tar() as tar:
+            paths = [tarinfo.path for tarinfo in tar]
+
+        self.fileobj.seek(0)
+
+        return paths
+
 
 class ArchiveTarZ(ArchiveBase):
     """ArchiveTar handles tar.Z archives.
@@ -510,6 +524,7 @@ class ArchiveTarZ(ArchiveBase):
                 _("Problem occured while uncompressing %s.Z file") % self.file_path
             )
 
+        files = self._tar_file_list()
         self.tar = tarfile.open(self.file_path)
 
         oldwd = None
@@ -524,6 +539,10 @@ class ArchiveTarZ(ArchiveBase):
         gid = os.getgid()
 
         for tarinfo in self.tar:
+            if is_usr_merged_duplicate(files, tarinfo.path):
+                ctx.ui.debug("Skipping merged file %s" % tarinfo.path)
+                continue
+
             self.tar.extract(tarinfo)
 
             # tarfile.extract does not honor umask. It must be honored
@@ -551,6 +570,12 @@ class ArchiveTarZ(ArchiveBase):
         except OSError:
             pass
         self.tar.close()
+
+    def _tar_file_list(self):
+        with tarfile.open(self.file_path) as tar:
+            paths = [tarinfo.path for tarinfo in tar]
+
+        return paths
 
 
 class Archive7Zip(ArchiveBase):
@@ -653,8 +678,14 @@ class ArchiveZip(ArchiveBase):
         unpacks stuff into target_dir and only extracts files
         from archive_root, treating it as the archive root"""
         zip_obj = self.zip_obj
+        files = [info.filename for info in zip_obj.infolist()]
+
         for info in zip_obj.infolist():
             if pred(info.filename):  # check if condition holds
+                if is_usr_merged_duplicate(files, info.filename):
+                    ctx.ui.debug("Skipping merged file %s" % info.filename)
+                    continue
+
                 # below code removes that, so we find it here
                 is_dir = info.filename.endswith("/")
 

--- a/pisi/atomicoperations.py
+++ b/pisi/atomicoperations.py
@@ -4,6 +4,7 @@
 """Atomic package operations such as install/remove/upgrade"""
 
 from pisi import translate as _
+from pisi.usr_merge import is_usr_merged_duplicate
 
 import os
 import shutil
@@ -621,6 +622,10 @@ class Remove(AtomicOperation):
         self.check_dependencies()
 
         for fileinfo in self.files.list:
+            if is_usr_merged_duplicate(self.files.list, fileinfo.path):
+                ctx.ui.debug("Not removing usr-merged file: %s" % fileinfo.path)
+                continue
+
             self.remove_file(fileinfo, self.package_name, True)
 
         self.update_databases()

--- a/pisi/package.py
+++ b/pisi/package.py
@@ -233,9 +233,12 @@ class Package:
         tar = self.get_install_archive()
 
         if tar:
-            tar.unpack_dir(outdir, callback=callback)
+            tar.unpack_dir(outdir, callback=callback, files=self._files())
         else:
             self.extract_dir_flat("install", outdir)
+
+    def _files(self):
+        return [f.path for f in self.files.list]
 
     def extract_dir_flat(self, dir, outdir):
         """Extract directory recursively, this function

--- a/pisi/usr_merge.py
+++ b/pisi/usr_merge.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2024 Solus Project
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+"""This module provides utility functions for usr merged systems."""
+
+import os.path
+import pisi.context as ctx
+import pisi.util
+
+from pisi.files import FileInfo
+
+
+def _islink(path):
+    return os.path.islink(pisi.util.join_path(ctx.config.dest_dir(), path))
+
+
+def is_usr_merged(path):
+    """
+    Check if the given path is usr merged by symlink.
+
+    :param path: Path to check. Must be relative to the destination directory.
+    :return: Boolean indicating if the file has been usr merged.
+    """
+    components = path.split('/')
+
+    if components[0] not in ['bin', 'sbin', 'lib', 'lib32', 'lib64']:
+        return False
+
+    for i, _ in enumerate(components[:-1]):
+        if _islink(os.path.join(*components[0:i + 1])):
+            return True
+
+    return False
+
+
+def is_usr_merged_duplicate(files, path):
+    """
+    Check if the given path is usr merged *and* a duplicate of an existing file.
+    All paths must be relative to the destination directory.
+
+    :param files: List of files to search in.
+    :param path: Path to check.
+    :return: Boolean indicating if the file is usr merged and a duplicate.
+    """
+    if not is_usr_merged(path):
+        return False
+
+    if len(files) > 0 and isinstance(files[0], FileInfo):
+        files = [f.path for f in files]
+
+    return usr_merged_path(path) in files
+
+
+def usr_merged_path(path):
+    """
+    Return the usr merged path equivalent of the given path.
+
+    :param path: Path to check. Must be relative to the destination directory.
+    :return: Boolean indicating if the usr merged file exists.
+    """
+    return os.path.join('usr', path)


### PR DESCRIPTION
This PR adds support for usr merged paths to the installation and removal functionality.

This change has a performance impact when installing larger packages because the list of files needs to be known when unpacking archives. For `linux-firmware` (a fairly large package) this increases the installation from 5.7s to 8.7s. The list of files known to the package is passed to the tar to mitigate this for the most common case.