### PR TITLE
Fix 3rd-party build failures for JetBrain IDEs (python2)

### DIFF
--- a/pisi/archive.py
+++ b/pisi/archive.py
@@ -482,7 +482,8 @@ class ArchiveTar(ArchiveBase):
         with self._open_tar() as tar:
             paths = [tarinfo.path for tarinfo in tar]
 
-        self.fileobj.seek(0)
+        if self.fileobj is not None:
+            self.fileobj.seek(0)
 
         return paths
 


### PR DESCRIPTION
Fixes https://github.com/getsolus/3rd-party/issues/81

So this is just a workaround because I'm not familiar with the code at all and don't know why a None fileobj propagates there

https://github.com/getsolus/eopkg/pull/81 doesn't change the behaviour mentioned in above issue