### PR TITLE
Fix exception when building certain pspec.xml files (python3)

### DIFF
--- a/pisi/archive.py
+++ b/pisi/archive.py
@@ -492,7 +492,8 @@ class ArchiveTar(ArchiveBase):
         with self._open_tar() as tar:
             paths = [tarinfo.path for tarinfo in tar]
 
-        self.fileobj.seek(0)
+        if self.fileobj is not None:
+            self.fileobj.seek(0)
 
         return paths
 


### PR DESCRIPTION
This is a port of #83 for python3.