### PR TITLE
helper.py: Move system.base pkgs to front of order

### DIFF
--- a/pisi/operations/helper.py
+++ b/pisi/operations/helper.py
@@ -14,7 +14,7 @@ import pisi.conflict
 import pisi.db
 
 
-def reorder_base_packages_old(order):
+def reorder_base_packages(order):
     componentdb = pisi.db.componentdb.ComponentDB()
 
     """system.base packages must be first in order"""
@@ -34,7 +34,7 @@ def reorder_base_packages_old(order):
         ctx.ui.info(_("install_order: %s" % install_order))
     return install_order
 
-def reorder_base_packages(order):
+def reorder_base_packages_dummy(order):
     """Dummy function that doesn't actually re-order system.base in front.
 
        We now use OrderedSets, which keep the original topological sort,


### PR DESCRIPTION
This change is made to test if our issues with ypkg-install-deps might be caused by not having system.base ordered first during upgrade and installs.

IF this solves it, THEN we also need to make this change for eopkg.py2 for consistency.