### PR TITLE
Revert "Merge pull request #41 from getsolus/filesdbornotdb"

### DIFF
--- a/pisi/db/filesdb.py
+++ b/pisi/db/filesdb.py
@@ -95,8 +95,6 @@ class FilesDB(lazydb.LazyDB):
         files_db = os.path.join(ctx.config.info_dir(), ctx.const.files_db)
 
         if not os.path.exists(files_db):
-            if not os.access(files_db, os.W_OK):
-                return
             flag = "n"
         elif os.access(files_db, os.W_OK):
             flag = "w"


### PR DESCRIPTION
This reverts commit 7aab9830e35a4770a28589a633fad11c51af8529, reversing changes made to 311e855cef6430547755c05d3e6412e0f7f727c3.

If the file didn't exist it would never get written.