### PR TITLE
eopkg.py2: Add explicit LazyDB and FilesDB pickle_protocol_version defaults

### DIFF
--- a/pisi/db/filesdb.py
+++ b/pisi/db/filesdb.py
@@ -25,6 +25,12 @@ import pisi.db.lazydb as lazydb
 # file conflict mechanism of pisi prevents this and needs a fast has_file function. 
 # So currently filesdb is the only db and we cant still get rid of rebuild-db :/
 
+# pickle protocol version 0 is a human-readable ASCII encoded format,
+# which is fine for DB use as it can then be introspected by querying the db
+# directly.
+# pickle protocol version 0 is the default in python2.
+FILESDB_PICKLE_PROTOCOL_VERSION = 0
+
 class FilesDB(lazydb.LazyDB):
 
     def init(self):
@@ -106,4 +112,4 @@ class FilesDB(lazydb.LazyDB):
         else:
             flag = "r"
 
-        self.filesdb = shelve.open(files_db, flag)
+        self.filesdb = shelve.open(files_db, flag, protocol=FILESDB_PICKLE_PROTOCOL_VERSION)

--- a/pisi/db/lazydb.py
+++ b/pisi/db/lazydb.py
@@ -20,6 +20,10 @@ import string
 # lower borks for international locales. What we want is ascii lower.
 lower_map = string.maketrans(string.ascii_uppercase, string.ascii_lowercase)
 
+# this is the pickle protocol version with which cache_version cache files
+# are written to disk in all LazyDB caches
+LAZYDB_PICKLE_PROTOCOL_VERSION = 1
+
 class Singleton(object):
     _the_instances = {}
     def __new__(type):
@@ -66,7 +70,7 @@ class LazyDB(Singleton):
                 f.flush()
                 os.fsync(f.fileno())
             cPickle.dump(self._instance().__dict__,
-                         file(self.__cache_file(), 'wb'), 1)
+                         file(self.__cache_file(), 'wb'), LAZYDB_PICKLE_PROTOCOL_VERSION)
 
     def cache_valid(self):
         if not self.cachedir:


### PR DESCRIPTION
This is to make it more obvious in the code what pickle protocol version a given pisi cache_version LazyDB file or FilesDB `files.db` database file will be written with.