### PR TITLE
Don't set compression level when opening an lzma archive for reading

### DIFF
--- a/pisi/archive.py
+++ b/pisi/archive.py
@@ -119,6 +119,9 @@ class TarFile(tarfile.TarFile):
         if fileobj is not None:
             fileobj = _LZMAProxy(fileobj, mode)
         else:
+            if mode == "r":
+                compresslevel = None
+
             fileobj = lzma.LZMAFile(name, mode, format=1, preset=compresslevel)
 
         try:


### PR DESCRIPTION
Fixes issues with Sublime Text (3rd-party) build

Part of https://github.com/getsolus/3rd-party/issues/78

Fixes this error:

```
<class 'ValueError'>: Cannot specify a preset compression level when opening a file for reading
Please use 'eopkg help' for general help.

Traceback:
  File "/usr/bin/eopkg.py3", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/lib/python3.11/site-packages/pisi/scripts/eopkg.py", line 78, in main
    cli.run_command()
  File "/usr/lib/python3.11/site-packages/pisi/cli/pisicli.py", line 131, in run_command
    self.command.run()
  File "/usr/lib/python3.11/site-packages/pisi/cli/build.py", line 209, in run
    pisi.api.build(x)
  File "/usr/lib/python3.11/site-packages/pisi/api.py", line 954, in build
    return pisi.atomicoperations.build(*args, **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/pisi/atomicoperations.py", line 723, in build
    return pisi.operations.build.build(package)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/pisi/operations/build.py", line 1780, in build
    pb.build()
  File "/usr/lib/python3.11/site-packages/pisi/operations/build.py", line 379, in build
    self.unpack_source_archives()
  File "/usr/lib/python3.11/site-packages/pisi/operations/build.py", line 569, in unpack_source_archives
    self.sourceArchives.unpack(self.pkg_work_dir())
  File "/usr/lib/python3.11/site-packages/pisi/sourcearchive.py", line 34, in unpack
    self.sourceArchives[0].unpack(target_dir, clean_dir)
  File "/usr/lib/python3.11/site-packages/pisi/sourcearchive.py", line 125, in unpack
    archive.unpack(target_dir, clean_dir)
  File "/usr/lib/python3.11/site-packages/pisi/archive.py", line 785, in unpack
    self.archive.unpack(target_dir, clean_dir)
  File "/usr/lib/python3.11/site-packages/pisi/archive.py", line 267, in unpack
    self.unpack_dir(target_dir)
  File "/usr/lib/python3.11/site-packages/pisi/archive.py", line 293, in unpack_dir
    self.tar = TarFile.lzmaopen(self.file_path, fileobj=self.fileobj)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/pisi/archive.py", line 121, in lzmaopen
    fileobj = lzma.LZMAFile(name, mode, format=1, preset=compresslevel)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/lzma.py", line 102, in __init__
    raise ValueError("Cannot specify a preset compression "
```