### PR TITLE
index: Show packages added on their own lines

### DIFF
--- a/pisi/index.py
+++ b/pisi/index.py
@@ -147,6 +147,7 @@ class Index(xmlfile.XmlFile, metaclass=autoxml.autoxml):
         if latest_packages:
             try:
                 # Add binary packages to index using a process pool
+                ctx.ui.info("Adding packages to index:")
                 self.packages = pool.map(add_package, latest_packages)
             except:
                 pool.terminate()
@@ -163,10 +164,7 @@ def add_package(params):
     try:
         path, deltas, repo_uri = params
 
-        ctx.ui.info(
-            "%-80.80s\r" % (_("Adding package to index: %s") % os.path.basename(path)),
-            noln=True,
-        )
+        ctx.ui.info("  %s" % os.path.basename(path))
 
         package = pisi.package.Package(path, "r")
         md = package.get_metadata()
@@ -236,14 +234,14 @@ def add_package(params):
 
 
 def add_groups(path):
-    ctx.ui.info(_("Adding groups.xml to index"))
+    ctx.ui.info("Adding groups.xml to index")
     groups_xml = group.Groups()
     groups_xml.read(path)
     return groups_xml.groups
 
 
 def add_components(path):
-    ctx.ui.info(_("Adding components.xml to index"))
+    ctx.ui.info("Adding components.xml to index")
     components_xml = component.Components()
     components_xml.read(path)
     # try:
@@ -254,7 +252,7 @@ def add_components(path):
 
 
 def add_distro(path):
-    ctx.ui.info(_("Adding distribution.xml to index"))
+    ctx.ui.info("Adding distribution.xml to index")
     distro = component.Distribution()
     # try:
     distro.read(path)
@@ -277,7 +275,7 @@ def add_spec(params):
             sf.source.sourceURI = util.removepathprefix(repo_uri, path)
 
         ctx.ui.info(
-            "%-80.80s\r" % (_("Adding %s to source index") % path),
+            "%-80.80s\r" % (("Adding %s to source index") % path),
             noln=False if ctx.config.get_option("verbose") else True,
         )
         return sf


### PR DESCRIPTION
Will make the index operation slightly more verbose, but also show the user which packages were added for a build, which is IMO a net benefit.

Example:

    sudo ./eopkg.py3 index --skip-signing /var/lib/solbuild/local/ --output /var/lib/solbuild/local/eopkg-index.xml
    Building index of eopkg files under /var/lib/solbuild/local/
    
    Adding packages to index:
      solbuild-config-local-unstable-1.7.0-55-1-x86_64.eopkg
      eopkg-4.1.5-17-1-x86_64.eopkg
      python-eopkg-4.1.5-17-1-x86_64.eopkg
      ypkg-33-195-1-x86_64.eopkg
      pisi-3.12.5-118-1-x86_64.eopkg
      solbuild-1.7.0-55-1-x86_64.eopkg
      solbuild-config-unstable-1.7.0-55-1-x86_64.eopkg
    
    Index file written