### PR TITLE
Avoid a nasty crash if a package has a malformed version string

### DIFF
--- a/pisi/atomicoperations.py
+++ b/pisi/atomicoperations.py
@@ -270,38 +270,24 @@ class Install(AtomicOperation):
             ipkg = self.installdb.get_package(pkg.name)
             (iversion_s, irelease_s, ibuild) = self.installdb.get_version(pkg.name)
 
-            # determine if same version
+            # determine if same distribution release
             if pkg.release == irelease_s:
                 if self.ask_reinstall:
-                    if not ctx.ui.confirm(_("Re-install same version package?")):
+                    if not ctx.ui.confirm(_("Re-install same distribution release of package?")):
                         raise Error(_("Package re-install declined"))
                 self.operation = REINSTALL
             else:
-                pkg_version = pisi.version.make_version(pkg.version)
-                iversion = pisi.version.make_version(iversion_s)
-
                 pkg_release = int(pkg.release)
                 irelease = int(irelease_s)
 
                 # is this an upgrade?
-                # determine and report the kind of upgrade: version, release
-                try:
-                    if pkg_version > iversion:
-                        ctx.ui.info(_("Upgrading to new upstream version"))
-                        self.operation = UPGRADE
-                except TypeError as e:
-                    ctx.ui.error(_("Malformed package version, falling back to distribution release"))
-                    ctx.ui.debug(str(e))
                 if pkg_release > irelease:
                     ctx.ui.info(_("Upgrading to new distribution release"))
                     self.operation = UPGRADE
 
                 # is this a downgrade? confirm this action.
                 if not self.operation == UPGRADE:
-                    if pkg_version < iversion:
-                        # x = _('Downgrade to old upstream version?')
-                        x = None
-                    elif pkg_release < irelease:
+                    if pkg_release < irelease:
                         x = _("Downgrade to old distribution release?")
                     else:
                         x = None

--- a/pisi/atomicoperations.py
+++ b/pisi/atomicoperations.py
@@ -285,10 +285,14 @@ class Install(AtomicOperation):
 
                 # is this an upgrade?
                 # determine and report the kind of upgrade: version, release
-                if pkg_version > iversion:
-                    ctx.ui.info(_("Upgrading to new upstream version"))
-                    self.operation = UPGRADE
-                elif pkg_release > irelease:
+                try:
+                    if pkg_version > iversion:
+                        ctx.ui.info(_("Upgrading to new upstream version"))
+                        self.operation = UPGRADE
+                except TypeError as e:
+                    ctx.ui.error(_("Malformed package version, falling back to distribution release"))
+                    ctx.ui.debug(str(e))
+                if pkg_release > irelease:
                     ctx.ui.info(_("Upgrading to new distribution release"))
                     self.operation = UPGRADE
 


### PR DESCRIPTION
Python 3 eopkg versions crash badly if a package has a malformed `version` string, such as `3.0.0d`. While we don't want versions formatted like that, it shouldn't crash eopkg completely. 

This PR makes that case an error (to alert packagers testing it to the issue), but allows package installation to succeed.

For context, the reason that we're making this case an error is that people on older eopkg 4.x versions will still experience an eopkg crash with a cryptic error message if they encounter malformed version strings.