### PR TITLE
CLI/index: Add valid compression types to help string

### DIFF
--- a/pisi/cli/index.py
+++ b/pisi/cli/index.py
@@ -56,7 +56,7 @@ class Index(command.Command, metaclass=command.autocommand):
             "--compression-types",
             action="store",
             default="xz",
-            help=_("Comma-separated compression types " "for index file"),
+            help=_("Comma-separated compression types " "for index file. Valid options are \"xz\" and \"bz2\". Defaults to \"xz\"."),
         )
 
         group.add_option(


### PR DESCRIPTION
This option either needs to be documented or deprecated. Documenting is easier in this case.

Closes #110.