### PR TITLE
Remove HTTP Basic-Auth repository support

### DIFF
--- a/dist/man/eopkg.1
+++ b/dist/man/eopkg.1
@@ -41,20 +41,6 @@ Change the system root for eopkg commands
 Assume yes in all yes/no queries
 .RE
 .IP \[bu] 2
-\f[V]-u\f[R], \f[V]--username\f[R]
-.RS 2
-.PP
-Set username used when connecting to Basic-Auth repositories.
-Rarely required.
-.RE
-.IP \[bu] 2
-\f[V]-p\f[R], \f[V]--password\f[R]
-.RS 2
-.PP
-Set password used when connecting to Basic-Auth repositories.
-Rarely required.
-.RE
-.IP \[bu] 2
 \f[V]-L\f[R], \f[V]--bandwidth-limit\f[R]
 .RS 2
 .PP

--- a/dist/man/eopkg.1.md
+++ b/dist/man/eopkg.1.md
@@ -25,14 +25,6 @@ The following options are applicable to `eopkg(1)`.
 
    Assume yes in all yes/no queries
 
- * `-u`, `--username`
-
-   Set username used when connecting to Basic-Auth repositories. Rarely required.
-
- * `-p`, `--password`
-
-   Set password used when connecting to Basic-Auth repositories. Rarely required.
-
  * `-L`, `--bandwidth-limit`
 
    Keep bandwidth usage under the specified (numeric) KBs

--- a/pisi/cli/command.py
+++ b/pisi/cli/command.py
@@ -101,8 +101,10 @@ class Command(object):
             default=False,
             help=_("Assume yes in all yes/no queries"),
         )
-        group.add_option("-u", "--username", action="store")
-        group.add_option("-p", "--password", action="store")
+        # Username and password are leftovers from auth-basic support.
+        # These are here (but hidden) so we can issue a deprecation warning.
+        group.add_option("-u", "--username", action="store", help=optparse.SUPPRESS_HELP)
+        group.add_option("-p", "--password", action="store", help=optparse.SUPPRESS_HELP)
         group.add_option(
             "-L",
             "--bandwidth-limit",
@@ -152,7 +154,8 @@ class Command(object):
         pass
 
     def process_opts(self):
-        self.check_auth_info()
+        if self.options.username or self.options.password:
+            raise pisi.cli.Error(_("HTTP Basic-Auth is no longer supported. Please reconfigure your repository."))
 
         # make destdir absolute
         if self.options.destdir:
@@ -164,30 +167,6 @@ class Command(object):
                 )
                 os.makedirs(d)
             self.options.destdir = os.path.realpath(d)
-
-    def check_auth_info(self):
-        username = self.options.username
-        password = self.options.password
-
-        # TODO: We'll get the username, password pair from a configuration
-        # file from users home directory. Currently we need user to
-        # give it from the user interface.
-        #         if not username and not password:
-        #             if someauthconfig.username and someauthconfig.password:
-        #                 self.authInfo = (someauthconfig.username,
-        #                                  someauthconfig.password)
-        #                 return
-        if username and password:
-            self.options.authinfo = (username, password)
-            return
-
-        if username and not password:
-            from getpass import getpass
-
-            password = getpass(_("Password: "))
-            self.options.authinfo = (username, password)
-        else:
-            self.options.authinfo = None
 
     def init(self, database=True, write=True):
         """initialize eopkg components"""

--- a/pisi/fetcher.py
+++ b/pisi/fetcher.py
@@ -109,9 +109,6 @@ class Fetcher:
         if not isinstance(url, pisi.uri.URI):
             url = pisi.uri.URI(url)
 
-        if ctx.config.get_option("authinfo"):
-            url.set_auth_info(ctx.config.get_option("authinfo"))
-
         self.url = url
         self.destdir = destdir
         self.destfile = destfile
@@ -225,9 +222,6 @@ class Fetcher:
 
     def _get_headers(self):
         headers = []
-        if self.url.auth_info():
-            enc = base64.encodestring("%s:%s" % self.url.auth_info())
-            headers.append(("Authorization", "Basic %s" % enc))
         headers.append(("User-Agent", "eopkg Fetcher/" + pisi.__version__))
         return headers
 

--- a/pisi/uri.py
+++ b/pisi/uri.py
@@ -27,8 +27,6 @@ class URI(object):
             self.__fragment = None
             self.__uri = None
 
-        self.__authinfo = None
-
     def get_uri(self):
         if self.__uri:
             return self.__uri
@@ -62,14 +60,6 @@ class URI(object):
 
     def is_relative_path(self):
         return not self.is_absolute_path()
-
-    def set_auth_info(self, authTuple):
-        if not isinstance(authTuple, tuple):
-            raise Exception(_("setAuthInfo needs a tuple (user, pass)"))
-        self.__authinfo = authTuple
-
-    def auth_info(self):
-        return self.__authinfo
 
     def scheme(self):
         return self.__scheme


### PR DESCRIPTION
This completely removes support for authenticating to eopkg repositories using HTTP Basic-Auth. 
Closes #108.

## Rationale
1. This isn't something we use or have any reason to use officially.
2. No one on the team has a worthwhile test case for this functionality.
3. `eopkg` has an abundance of features which are rarely or never used, and the codebase is very difficult to maintain. Removing unused or impractical non-features such as this reduces code complexity and test surface area.

## Test Plan
1. Check out this PR.
2. Try `eopkg --username=someuser <command>` and note that you now receive an error.
3. Do the same test with `--password` and the shorthand arguments `-p` and `-u`.
4. Try some basic operations requiring fetches from the server (install, remove, update, fetch, etc.) normally and see that they still work.
