### PR TITLE
Move call to list_upgradable out of inner loop

### DIFF
--- a/pisi/atomicoperations.py
+++ b/pisi/atomicoperations.py
@@ -233,6 +233,7 @@ class Install(AtomicOperation):
                 ):
                     file_conflicts.append((pkg, existing_file))
         if file_conflicts:
+            upgradable_pkgs = pisi.api.list_upgradable()
             file_conflicts_str = ""
             for pkg, existing_file in file_conflicts:
                 paths = [fileinfo.path for fileinfo in self.files.list]
@@ -241,7 +242,7 @@ class Install(AtomicOperation):
                     # FIXME: If the package is in the updates list assume it's been vetted for now...
                     #        What we really want to do is see if the conflicting pkg exists in the
                     #        install order and the conflicting file no longer exists there.
-                    if pkg in pisi.api.list_upgradable():
+                    if pkg in upgradable_pkgs:
                         file_conflicts_str += _(
                             "/%s from %s gets replaced by %s package\n"
                         ) % (existing_file, pkg, self.pkginfo.name)


### PR DESCRIPTION
When upgrading a package creates file conflicts, we need to check that the conflicting package is also slated for upgrade. In that case, we can be reasonably certain that the conflict isn't an actual problem (see 7895e0b for details). 

The current operational issue with this code is that it if a package has N file conflicts, we make N calls to `pisi.api.list_upgradable()`. That call is very intensive, causing the upgrade operation to take a very, very long time and cause extremely heavy load on system resources. If we move the call to `pisi.api.list_upgradable` out of the inner for loop, we can make that call only once per *package containing file conflicts*, rather than once per *conflicting file*. The list of upgradable packages won't change while we're in the process of installing a single package, so the functionality of this code should be identical. 

A couple of test runs, first using the current code:
```
❯ time sudo eopkg.py3 --yes up nodejs
Updating repositories
Updating repository: Shannon
eopkg-index.xml.xz.sha1sum     (40.0  B)100%      0.00 --/- [--:--:--] [complete]
Shannon repository information is up-to-date.
Updating repository: Unstable
eopkg-index.xml.xz.sha1sum     (40.0  B)100%      0.00 --/- [--:--:--] [complete]
Unstable repository information is up-to-date.
The following packages will be upgraded:
nodejs  nodejs-20
Total size of package(s): 12.70 MB
There are extra packages due to dependencies.
Downloading 1 / 2
Package nodejs-20 found in repository Shannon
nodejs-20-20.18.1-2-1-x86_64.eopkg [cached]
Downloading 2 / 2
Package nodejs found in repository Shannon
nodejs-20-123-1-x86_64.eopkg [cached]
Installing 1 / 2
nodejs-20-20.18.1-2-1-x86_64.eopkg [cached]
Installing nodejs-20, version 20.18.1, release 2
-snip eopkg conflict warnings-
 [✓] Syncing filesystems                                                success
 [✓] Updating dynamic library cache                                     success
 [✓] Updating manpages database                                         success

real    11m44.389s
user    0m0.010s
sys     0m0.039s
```

And then using this PR:

```
❯ time sudo ./eopkg.py3 --yes up nodejs
Updating repositories
Updating repository: Shannon
eopkg-index.xml.xz.sha1sum     (40.0  B)100%      0.00 --/- [--:--:--] [complete]
Shannon repository information is up-to-date.
Updating repository: Unstable
eopkg-index.xml.xz.sha1sum     (40.0  B)100%      0.00 --/- [--:--:--] [complete]
Unstable repository information is up-to-date.
The following packages will be upgraded:
nodejs  nodejs-20
Total size of package(s): 12.70 MB
There are extra packages due to dependencies.
Downloading 1 / 2
Package nodejs-20 found in repository Shannon
nodejs-20-20.18.1-2-1-x86_64.eopkg [cached]
Downloading 2 / 2
Package nodejs found in repository Shannon
nodejs-20-123-1-x86_64.eopkg [cached]
Installing 1 / 2
nodejs-20-20.18.1-2-1-x86_64.eopkg [cached]
Installing nodejs-20, version 20.18.1, release 2
-snip eopkg conflict warnings-
Upgraded nodejs
 [✓] Syncing filesystems                                                success
 [✓] Updating dynamic library cache                                     success
 [✓] Updating manpages database                                         success

real    0m14.466s
user    0m0.015s
sys     0m0.080s
```

**Test Plan**
- Try the reproduction steps in #103 and save the text output.
- Check out this PR.
- Try the reproduction steps in #103 with this PR applied and save the text output in a new file.
- `diff` the two outputs to see that the file conflict warnings between the two are identical.
- Note the dramatic speedup (on my system, nearly 12 minutes down to 14 seconds).

This change resolves #103. Thanks to @Staudey for posting cProfile runs which allowed me to debug this easily.
