### PR TITLE
pisi.cli.help: Import all commands that sort alphabetically after help

### DIFF
--- a/pisi/cli/help.py
+++ b/pisi/cli/help.py
@@ -7,6 +7,30 @@ import pisi.cli
 import pisi.cli.command as command
 import pisi.context as ctx
 
+# Import all the commands that are alphabetically after help
+# We need to force-import all of these or help is truncated due to how pisi.command.autocommand is written.
+# TODO: Modernize the entire CLI and remove this nonsense.
+from pisi.cli.history import History
+from pisi.cli.index import Index
+from pisi.cli.info import Info
+from pisi.cli.install import Install
+from pisi.cli.listavailable import ListAvailable
+from pisi.cli.listcomponents import ListComponents
+from pisi.cli.listinstalled import ListInstalled
+from pisi.cli.listnewest import ListNewest
+from pisi.cli.listpending import ListPending
+from pisi.cli.listrepo import ListRepo
+from pisi.cli.listupgrades import ListUpgrades
+from pisi.cli.rebuilddb import RebuildDb
+from pisi.cli.remove import Remove
+from pisi.cli.removeorphans import RemoveOrphans
+from pisi.cli.removerepo import RemoveRepo
+from pisi.cli.repopriority import RepoPriority
+from pisi.cli.search import Search
+from pisi.cli.searchfile import SearchFile
+from pisi.cli.updaterepo import UpdateRepo
+from pisi.cli.upgrade import Upgrade
+
 
 class Help(command.Command, metaclass=command.autocommand):
     __doc__ = _(


### PR DESCRIPTION
I'm fairly certain that we need to force-import all of these or help is truncated due to how `pisi.command.autocommand` is written.

My guess is that this (or a nearly identical strategy) worked in python2 because of differently-optimized processing and ordering of imports. I think perhaps the python3 interpreter only loads up to the code it's actually running when importing a large module (like `pisi.cli`, for example), and in effect doesn't know about code it's never going to call.

In any case, importing all the things *does* fix the problem.

In the future, I would ideally like to rip out all of this stuff and massively refactor `pisi.cli`, but we're stuck with this *very* python2-ish `optparse` hackery for now. Big refactoring efforts are going to have to wait until the current deployment push is finished.

**Test Plan**
1. Try `eopkg.py3 help` on your system and see that the list of subcommands is truncated after `help`.
2. Check out this PR and run `./eopkg.py3 help` and see that the output is no longer truncated.
3. Scratch your head in confusion.
4. Go back later and investigate such incomprehensible atrocities as `pisi.command.autocommand` and, with eyes unfocused, start to understand how this bug might be occurring.
5. Decide that you'd rather not dive down that rabbit hole and approve this PR because hey, at least it works.

Fixes #50.