### PR TITLE
pisi.cli.build: Fail with a readable error when attempting to build packages using a compiled eopkg

### DIFF
--- a/pisi/cli/build.py
+++ b/pisi/cli/build.py
@@ -184,6 +184,9 @@ class Build(command.Command, metaclass=command.autocommand):
         self.parser.add_option_group(group)
 
     def run(self):
+        if "__compiled__" in globals():
+            raise pisi.Error(_("Building packages is not supported when eopkg is compiled with nuitka. Please use eopkg.py3 instead."))
+
         if not self.options.quiet:
             self.options.debug = True
 


### PR DESCRIPTION
This is possibly an overly ham-fisted approach to solving #49. I think that some of the dynamic import stuff inside eopkg's build code just doesn't work in nuitka. I think there's a way to compile programs in a hybrid mode which would run certain pieces of the program as interpreted, which may fix this, but that seems like a lot of work just for a feature whose main purpose (3rd party) deprecated and will be removed. 

**Test Plan**
1. Build and install the `eopkg` package using this PR.
2. Run `eopkg.bin bi`. Note the error and exit.
3. Run `eopkg.py3 bi`. Note the different error (lacking a file to build). This proves that the PR is working. The check being done will stop all `build` operations using a compiled version of eopkg, while operations using interpreted `eopkg` are unaffected.