### PR TITLE
Fix deprecated license declaration format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "eopkg"
-license = { text = "GPL-2.0-or-later" }
+license = "GPL-2.0-or-later"
 description = "eopkg is the package management system of Solus Operating System, originally written for Pardus Linux by the Pardus Developers."
 readme = "README.md"
 authors = [{ name = "Solus Project", email = "releng@getsol.us" }]


### PR DESCRIPTION
Fix the deprecated license declaration format by adjusting it to PEP 639

Fixes the following deprecation warning:

```
/usr/lib/python3.12/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
!!

        ********************************************************************************
        Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

        By 2026-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
```