### PR TITLE
pisi: Inhibit the system from going down during operations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 PyYaml
 iksemel
+jeepney
 python-magic
 xattr


### PR DESCRIPTION
Wrap the locked decorator to hold a fd from the systemd-inhibit interface until the operation is completed.

https://www.freedesktop.org/software/systemd/man/latest/systemd-inhibit.html

Resolves #46