### PR TITLE
filesdb: Fix localization formatting

### DIFF
--- a/pisi/db/filesdb.py
+++ b/pisi/db/filesdb.py
@@ -338,7 +338,7 @@ class FilesDB(lazydb.LazyDB):
                     ctx.ui.info("-------------")
                 else:
                     ctx.ui.info(".", noln=True)
-        ctx.ui.info(ngettext("\nOne package added in total.", "\n%s packages added in total.", pkgs))
+        ctx.ui.info(ngettext("\n%(num)d package added in total.", "\n%(num)d packages added in total.", pkgs) % {"num": pkgs})
         # ensure that the changes get pushed out to disk
         self.filesdb.sync()
         # This acts as a check that the version has been correctly added and synced to disk


### PR DESCRIPTION
**Summary**

Note that this needs the pot file to be updated, which already has to be done anyways. Let's do that in a separate PR.

Fixes https://github.com/getsolus/eopkg/issues/130

**Test Plan**

Tested by updating the pot file, and running `sudo ./eopkg.py3 rdb`.
