### PR TITLE
eopkg.py3.handle_exception: Show traceback on `pisi.Error` (not just on `pisi.Exception`) if `--debug` is specified.

### DIFF
--- a/eopkg.py3
+++ b/eopkg.py3
@@ -34,6 +34,7 @@ def handle_exception(exception, value, tb):
         exit()
     elif isinstance(value, pisi.Error):
         ui.error(_("Program terminated."))
+        show_traceback = ctx.get_option("debug")
     elif isinstance(value, pisi.Exception):
         show_traceback = True
         ui.error(


### PR DESCRIPTION
Tiny little change. Rationale: 
- If you're debugging, you probably want to see a traceback.
- If you're debugging, there is quite possibly nothing more frustrating than "**Program Terminated.**" with no further errors even when `--debug` is specified.

There may be a more elegant way to handle this, but that's going to be a problem for another day.