### PR TITLE
atomicoperations: Warn when attempting to remove a deleted config file

### DIFF
--- a/pisi/atomicoperations.py
+++ b/pisi/atomicoperations.py
@@ -670,6 +670,13 @@ class Remove(AtomicOperation):
                         os.unlink(fpath)
             except pisi.util.FileError:
                 pass
+            except pisi.util.FileNotFoundError:
+                ctx.ui.warning(
+                    _(
+                        "Installed config file %s does not exist on system [Probably you manually deleted]"
+                    )
+                    % fpath
+                )
         else:
             if os.path.isfile(fpath) or os.path.islink(fpath):
                 os.unlink(fpath)


### PR DESCRIPTION
Previously, if a file known to PiSi as a config file was removed before the `remove` operation started, `eopkg` would crash with an ugly error, potentially leaving the system in a broken state. The problem originates with a logic fault - most already-removed files simply result in warnings when their package is removed. However, checking that the file exists, we check to see if a file is a configuration file. If it is, we check the hash to see if the file was changed after installation. **This hash comparison fails** if the file does not exist. The remove operation checks for `pisi.FileError`, but *not* `pisi.FileNotFoundError` when comparing the file hash. If the file is not found, the resulting exception is not caught, and `eopkg` crashes.

This PR adds proper exception handling for `pisi.FileNotFoundError`, with a warning based on the one we use for other types of previously-removed files. With this PR applied, the above situation will simply emit a warning.

**Test Plan**
1. Check out this PR.
2. Create a bash script called `setup-test-env.sh` in this repository's directory:
```bash
#!/bin/bash
mkdir tmprootfs
sudo eopkg ar Solus https://cdn.getsol.us/repo/unstable/eopkg-index.xml.xz -D ./tmprootfs
sudo eopkg it -c system.base -D ./tmprootfs
sudo tar cf goodroot.tar tmprootfs
``` 
3. Create a bash script called `reset-env.sh` in this repository's directory:
```bash
#!/bin/bash
sudo rm -rf tmprootfs
sudo tar xf goodroot.tar
```
4. Create a basic `eopkg` root directory using `bash setup-test-env.sh`.
5. Remove a piece of OpenSSL from your test environment: ` sudo rm -rf ./tmprootfs/etc/ssl/certs/`.
6. Attempt to remove OpenSSL from your test environment using your system's `eopkg`: `sudo eopkg rm -D ./tmprootfs openssl --ignore-safety --debug`.
7. Note that the operation fails with "**Program terminated. Unable to read file (...)**". 
8. Attempt some other `eopkg` operations with `-D ./tmprootfs`, especially `install` operations. Note that metadata files are missing, causing the whole system to fail. In my testing, the only way to remedy this is to manually copy the missing `metadata.xml` files out of extracted `.eopkg` files.
9. Reset your testing environment using `bash reset-env.sh`.
10. Remove a piece of OpenSSL from your test environment: ` sudo rm -rf ./tmprootfs/etc/ssl/certs/`.
11. Attempt to remove OpenSSL from your test environment using **this PR's modified**` eopkg`: `sudo ./eopkg.py3 rm -D ./tmprootfs openssl --ignore-safety --debug`.
12. Note that the operation now succeeds, with a warning like "Installed config file /home/sheepman/Solus/eopkg/tmprootfs/etc/ssl/certs does not exist on system [Probably you manually deleted]".
13. Attempt some other `eopkg` operations with `-D ./tmprootfs`, using either your system's `eopkg` or the `eopkg.py3` from this PR. Note that further operations now succeed.