### PR TITLE
pisi.cli.check: Rewrite warning to not reference Pisi

### DIFF
--- a/pisi/cli/check.py
+++ b/pisi/cli/check.py
@@ -139,10 +139,8 @@ class Check(command.Command, metaclass=command.autocommand):
             ctx.ui.info("")
             ctx.ui.warning(
                 _(
-                    "Pisi was unable to check the integrity of "
-                    "packages which contain files that you don't "
-                    "have read access.\n"
-                    "Running the check under a privileged user "
-                    "may help fixing this problem."
+                    "Could not check the integrity of packages which contain files your user "
+                    "did not have permission to read.\n"
+                    "Running the check under a privileged user may help to fix this problem."
                 )
             )


### PR DESCRIPTION
Changes the message 
> Pisi was unable to check the integrity of packages which contain files that you don't have read access. 
> Running the check under a privileged user may help fixing this problem.

to 
> Could not check the integrity of packages which contain files your user did not have permission to read.
> Running the check under a privileged user may help to fix this problem.

Fixes #138.
