### PR TITLE
pisi: Fix crash when adding a deactivated repo

### DIFF
--- a/pisi/db/repodb.py
+++ b/pisi/db/repodb.py
@@ -271,7 +271,7 @@ class RepoDB(lazydb.LazyDB):
         return repos
 
     def get_repo_by_url(self, url):
-        if not self.has_repo_url(url):
+        if not self.has_repo_url(url, only_active=False):
             return None
 
         for r in self.list_repos(only_active=False):


### PR DESCRIPTION
Fix an issue where `add-repo` would crash when adding a repository that exists, but was deactivated.

Resolves #149 