### PR TITLE
list-installed: Add option for explicitly installed packages

### DIFF
--- a/dist/man/eopkg.1
+++ b/dist/man/eopkg.1
@@ -641,6 +641,19 @@ Show a list of all installed packages.
  installed as a dependency of other packages, along with
  the package they are still associated with. Orphaned
  packages with no relationship will be clearly listed.
+
+ Cannot be used with \[ga]\-\-explicit\[ga].
+.EE
+.RE
+.IP \[bu] 2
+\f[CR]\-e\f[R], \f[CR]\-\-explicit\f[R]:
+.RS 2
+.IP
+.EX
+ Show a list of all packages that have been installed explicitly
+ by a user.
+
+ Cannot be used with \[ga]\-\-automatic\[ga].
 .EE
 .RE
 .IP \[bu] 2

--- a/dist/man/eopkg.1.md
+++ b/dist/man/eopkg.1.md
@@ -411,6 +411,15 @@ alias, if available. Most commands in eopkg support a short form.
         the package they are still associated with. Orphaned
         packages with no relationship will be clearly listed.
 
+        Cannot be used with `--explicit`.
+
+ * `-e`, `--explicit`:
+
+        Show a list of all packages that have been installed explicitly
+        by a user.
+
+        Cannot be used with `--automatic`.
+
  * `-b`, `--with-build-host`:
 
         Only show packages that come from a particular build host.


### PR DESCRIPTION
**Summary**

This adds an option to the `list-installed` command to list only packages that were explicitly installed by a user of the system. The manpage was re-generated accordingly.

Fixes https://github.com/getsolus/eopkg/issues/126

**Test Plan**

Run `./eopkg.py3 list-installed --explicit`. I have a crapton of manually installed packages on my system as a result of compiling various software, so it's extremely hard for me to tell if a package was truly installed by me or not.
