### PR TITLE
api,cli: Add checking for active repositories

### DIFF
--- a/pisi/api.py
+++ b/pisi/api.py
@@ -1037,3 +1037,16 @@ def clearCache(all=False):
         removeOrderByLimit(cacheDir, order, cacheLimit)
     else:
         removeAll(cacheDir)
+
+
+def has_active_repositories() -> bool:
+    """
+    Check whether there are any active repositories configured
+    on the system.
+
+        Returns:
+            has_repos (bool): True if there are any active repositories
+    """
+    active_repos = pisi.db.repodb.RepoDB().list_repos(True)
+    has_repos = len(active_repos) > 0
+    return has_repos

--- a/pisi/cli/fetch.py
+++ b/pisi/cli/fetch.py
@@ -49,4 +49,8 @@ Downloads the given pisi packages to working directory
             self.help()
             return
 
+        if not pisi.api.has_active_repositories():
+            ctx.ui.error(_("No active repositories found"))
+            return
+
         pisi.api.fetch(self.args, ctx.config.options.output_dir)

--- a/pisi/cli/info.py
+++ b/pisi/cli/info.py
@@ -71,6 +71,10 @@ Usage: info <package1> <package2> ... <packagen>
     def run(self):
         self.init(database=True, write=False)
 
+        if not pisi.api.has_active_repositories():
+            ctx.ui.error(_("No active repositories found"))
+            return
+
         components = ctx.get_option("component")
         if not components and not self.args:
             self.help()

--- a/pisi/cli/install.py
+++ b/pisi/cli/install.py
@@ -117,6 +117,10 @@ expanded to package names.
         else:
             self.init()
 
+        if not pisi.api.has_active_repositories():
+            ctx.ui.error(_("No active repositories found"))
+            return
+
         components = ctx.get_option("component")
         if not components and not self.args:
             self.help()

--- a/pisi/cli/listavailable.py
+++ b/pisi/cli/listavailable.py
@@ -59,6 +59,10 @@ all repositories.
     def run(self):
         self.init(database=True, write=False)
 
+        if not pisi.api.has_active_repositories():
+            ctx.ui.error(_("No active repositories found"))
+            return
+
         if not (ctx.get_option("no_color") or ctx.config.get_option("uninstalled")):
             ctx.ui.info(
                 util.colorize(_("Installed packages are shown in this color"), "green")

--- a/pisi/cli/listcomponents.py
+++ b/pisi/cli/listcomponents.py
@@ -49,6 +49,10 @@ repositories.
     def run(self):
         self.init(database=True, write=False)
 
+        if not pisi.api.has_active_repositories():
+            ctx.ui.error(_("No active repositories found"))
+            return
+
         l = self.componentdb.list_components(ctx.get_option("repository"))
         l.sort()
         for p in l:

--- a/pisi/cli/listnewest.py
+++ b/pisi/cli/listnewest.py
@@ -55,6 +55,10 @@ packages from all repositories.
     def run(self):
         self.init(database=True, write=False)
 
+        if not pisi.api.has_active_repositories():
+            ctx.ui.error(_("No active repositories found"))
+            return
+
         if self.args:
             for arg in self.args:
                 self.print_packages(arg)

--- a/pisi/cli/listupgrades.py
+++ b/pisi/cli/listupgrades.py
@@ -56,6 +56,11 @@ Lists the packages that will be upgraded.
 
     def run(self):
         self.init(database=True, write=False)
+
+        if not pisi.api.has_active_repositories():
+            ctx.ui.error(_("No active repositories found"))
+            return
+
         upgradable_pkgs = pisi.api.list_upgradable()
 
         component = ctx.get_option("component")

--- a/pisi/cli/search.py
+++ b/pisi/cli/search.py
@@ -82,6 +82,10 @@ database.
             self.help()
             return
 
+        if not pisi.api.has_active_repositories():
+            ctx.ui.error(_("No active repositories found"))
+            return
+
         replace = re.compile("(%s)" % "|".join(self.args), re.I)
         lang = ctx.get_option("language")
         repo = ctx.get_option("repository")

--- a/pisi/cli/searchfile.py
+++ b/pisi/cli/searchfile.py
@@ -59,6 +59,10 @@ Finds the installed package which contains the specified file.
             self.help()
             return
 
+        if not pisi.api.has_active_repositories():
+            ctx.ui.error(_("No active repositories found"))
+            return
+
         # search among existing files
         for path in self.args:
             if not ctx.config.options.quiet:

--- a/pisi/cli/upgrade.py
+++ b/pisi/cli/upgrade.py
@@ -116,6 +116,10 @@ expanded to package names.
         else:
             self.init()
 
+        if not pisi.api.has_active_repositories():
+            ctx.ui.error(_("No active repositories found"))
+            return
+
         if not ctx.get_option("bypass_update_repo"):
             ctx.ui.info(_("Updating repositories"))
             repos = pisi.api.list_repos()


### PR DESCRIPTION
**Summary**

Some commands require an active repository to be configured on the system in order to be able to function. If no repositories are configured, they may fail silently, or in other unexpected ways. This solves that issue by adding an API function to check for the presence of active repositories, and having the CLI bail with a message if none are found.

This may not encompass the entire list of commands that need to check for repositories, but at least it's a good start.

Ref https://github.com/getsolus/eopkg/issues/106

**Test Plan**

Disable all repositories on my system, and try to search for packages.
