### PR TITLE
fetcher: Handle the correct exception from urllib

### DIFF
--- a/pisi/fetcher.py
+++ b/pisi/fetcher.py
@@ -13,6 +13,7 @@ import os
 import shutil
 import time
 import urllib.request, urllib.error, urllib.parse
+from urllib.error import URLError
 
 from pisi import translate as _
 
@@ -195,7 +196,7 @@ class Fetcher:
                             blocknum += 1
                             fetch_handler.update(blocknum, bs, size)
                     success = True
-            except IOError as e:
+            except URLError as e:
                 attempt += 1
                 if attempt == self._get_retry_attempts() + 1:
                     raise FetchError(


### PR DESCRIPTION
**Summary**

In Python 3.3, URLError is now a subtype of OSError instead of IOError.

Fixes https://github.com/getsolus/eopkg/issues/148

**Test Plan**

TBD. I don't really know how to test this one.
