### PR TITLE
signalhandler: Refactor signal handling

### DIFF
--- a/pisi/__init__.py
+++ b/pisi/__init__.py
@@ -9,8 +9,11 @@ import locale
 import logging
 import logging.handlers
 import os
+import signal
 import sys
 from importlib.resources import files
+
+import pisi.signalhandler as signalhandler
 
 
 locale.setlocale(locale.LC_ALL, "")
@@ -75,7 +78,9 @@ def init_logging():
 
 def _cleanup():
     """Close the database cleanly and do other cleanup."""
-    ctx.disable_keyboard_interrupts()
+    signal_handler = signalhandler.SignalHandler()
+
+    signal_handler.disable_signal(signal.SIGINT)
     if ctx.log:
         ctx.loghandler.flush()
         ctx.log.removeHandler(ctx.loghandler)
@@ -88,7 +93,7 @@ def _cleanup():
         os.unlink(ctx.build_leftover)
 
     ctx.ui.close()
-    ctx.enable_keyboard_interrupts()
+    signal_handler.enable_signal(signal.SIGINT)
 
 
 # Hack for pisi to work with non-patched Python. pisi needs

--- a/pisi/api.py
+++ b/pisi/api.py
@@ -886,6 +886,7 @@ def update_repo(repo, force=False):
 def __update_repo(repo, force=False):
     ctx.ui.action(_("Updating repository: %s") % repo)
     ctx.ui.notify(pisi.ui.updatingrepo, name=repo)
+    ctx.ui.info(_("Disabling keyboard interrupts for file operations."))
     ctx.disable_keyboard_interrupts()
 
     repodb = pisi.db.repodb.RepoDB()
@@ -928,6 +929,7 @@ def rebuild_db(files=False):
     set_userinterface(ui)
     set_options(options)
 
+    ctx.ui.info(_("Disabling keyboard interrupts for file operations."))
     ctx.disable_keyboard_interrupts()
 
     filesdb = pisi.db.filesdb.FilesDB()

--- a/pisi/api.py
+++ b/pisi/api.py
@@ -886,6 +886,8 @@ def update_repo(repo, force=False):
 def __update_repo(repo, force=False):
     ctx.ui.action(_("Updating repository: %s") % repo)
     ctx.ui.notify(pisi.ui.updatingrepo, name=repo)
+    ctx.disable_keyboard_interrupts()
+
     repodb = pisi.db.repodb.RepoDB()
     index = pisi.index.Index()
     if repodb.has_repo(repo):
@@ -898,13 +900,17 @@ def __update_repo(repo, force=False):
                 ctx.ui.info(_("Updating database at any rate as requested"))
                 index.read_uri_of_repo(repouri, repo, force=force)
             else:
+                ctx.enable_keyboard_interrupts()
                 return False
 
         pisi.db.historydb.HistoryDB().update_repo(repo, repouri, "update")
         repodb.check_distribution(repo)
         ctx.ui.info(_("Package database updated."))
     else:
+        ctx.enable_keyboard_interrupts()
         raise pisi.Error(_("No repository named %s found.") % repo)
+
+    ctx.enable_keyboard_interrupts()
 
     return True
 
@@ -922,8 +928,12 @@ def rebuild_db(files=False):
     set_userinterface(ui)
     set_options(options)
 
+    ctx.disable_keyboard_interrupts()
+
     filesdb = pisi.db.filesdb.FilesDB()
     filesdb.init(force_rebuild=True)
+
+    ctx.enable_keyboard_interrupts()
 
 ############# FIXME: this was a quick fix. ##############################
 

--- a/pisi/atomicoperations.py
+++ b/pisi/atomicoperations.py
@@ -170,13 +170,10 @@ class Install(AtomicOperation):
         self.check_relations()
         self.check_operation()
 
-        ctx.disable_keyboard_interrupts()
-
         self.extract_install()
         self.store_pisi_files()
         self.update_databases()
 
-        ctx.enable_keyboard_interrupts()
         ctx.ui.close()
         if self.operation == UPGRADE:
             event = pisi.ui.upgraded
@@ -611,8 +608,6 @@ class Remove(AtomicOperation):
 
         self.check_dependencies()
 
-        ctx.disable_keyboard_interrupts()
-
         for fileinfo in self.files.list:
             if is_usr_merged_duplicate(self.files.list, fileinfo.path):
                 ctx.ui.debug("Not removing usr-merged file: %s" % fileinfo.path)
@@ -624,7 +619,6 @@ class Remove(AtomicOperation):
 
         self.remove_pisi_files()
 
-        ctx.enable_keyboard_interrupts()
         ctx.ui.close()
         ctx.ui.notify(pisi.ui.removed, package=self.package, files=self.files)
 

--- a/pisi/atomicoperations.py
+++ b/pisi/atomicoperations.py
@@ -177,7 +177,6 @@ class Install(AtomicOperation):
         self.update_databases()
 
         ctx.enable_keyboard_interrupts()
-
         ctx.ui.close()
         if self.operation == UPGRADE:
             event = pisi.ui.upgraded
@@ -612,6 +611,8 @@ class Remove(AtomicOperation):
 
         self.check_dependencies()
 
+        ctx.disable_keyboard_interrupts()
+
         for fileinfo in self.files.list:
             if is_usr_merged_duplicate(self.files.list, fileinfo.path):
                 ctx.ui.debug("Not removing usr-merged file: %s" % fileinfo.path)
@@ -622,6 +623,8 @@ class Remove(AtomicOperation):
         self.update_databases()
 
         self.remove_pisi_files()
+
+        ctx.enable_keyboard_interrupts()
         ctx.ui.close()
         ctx.ui.notify(pisi.ui.removed, package=self.package, files=self.files)
 

--- a/pisi/cli/history.py
+++ b/pisi/cli/history.py
@@ -146,4 +146,6 @@ Lists previous operations."""
                 self.takeback(opno)
                 return
 
+        ctx.disable_keyboard_interrupts(should_hold=False)
         self.redirect_output(self.print_history)
+        ctx.enable_keyboard_interrupts()

--- a/pisi/cli/history.py
+++ b/pisi/cli/history.py
@@ -146,6 +146,6 @@ Lists previous operations."""
                 self.takeback(opno)
                 return
 
-        ctx.disable_keyboard_interrupts(should_hold=False)
+        ctx.disable_keyboard_interrupts()
         self.redirect_output(self.print_history)
         ctx.enable_keyboard_interrupts()

--- a/pisi/cli/history.py
+++ b/pisi/cli/history.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 import os
+import signal
 import sys
 import optparse
 
@@ -12,6 +13,7 @@ import pisi.api
 import pisi.db
 import pisi.context as ctx
 import pisi.cli.command as command
+import pisi.signalhandler as signalhandler
 
 # Operation names for translation
 opttrans = {
@@ -37,6 +39,7 @@ Lists previous operations."""
     def __init__(self, args=None):
         super(History, self).__init__(args)
         self.historydb = pisi.db.historydb.HistoryDB()
+        self.signal_handler = signalhandler.SignalHandler()
 
     name = ("history", "hs")
 
@@ -146,6 +149,5 @@ Lists previous operations."""
                 self.takeback(opno)
                 return
 
-        ctx.disable_keyboard_interrupts()
+        self.signal_handler.disable_signal(signal.SIGINT)
         self.redirect_output(self.print_history)
-        ctx.enable_keyboard_interrupts()

--- a/pisi/context.py
+++ b/pisi/context.py
@@ -49,18 +49,6 @@ can_usysconf = True
 build_leftover = None
 
 
-def disable_keyboard_interrupts():
-    """
-    Temporarily disable keyboard interrupt signals.
-    """
-    sig and sig.disable_signal(signal.SIGINT)
-
-
-def enable_keyboard_interrupts():
-    """Re-enable keyboard interrupt signals."""
-    sig and sig.enable_signal(signal.SIGINT)
-
-
 def exec_usysconf():
     """Just stick this all in the one place"""
     global ui

--- a/pisi/context.py
+++ b/pisi/context.py
@@ -49,24 +49,16 @@ can_usysconf = True
 build_leftover = None
 
 
-def disable_keyboard_interrupts(should_hold: bool = True):
+def disable_keyboard_interrupts():
     """
     Temporarily disable keyboard interrupt signals.
-
-    Parameters:
-        should_hold (bool, optional): Whether the signal should be emitted when
-            being re-enabled. Defaults to True.
     """
-    sig and sig.disable_signal(signal.SIGINT, should_hold)
+    sig and sig.disable_signal(signal.SIGINT)
 
 
 def enable_keyboard_interrupts():
     """Re-enable keyboard interrupt signals."""
     sig and sig.enable_signal(signal.SIGINT)
-
-
-def keyboard_interrupt_disabled():
-    return sig and sig.signal_disabled(signal.SIGINT)
 
 
 def exec_usysconf():

--- a/pisi/context.py
+++ b/pisi/context.py
@@ -49,20 +49,24 @@ can_usysconf = True
 build_leftover = None
 
 
-def disable_keyboard_interrupts():
-    sig and sig.disable_signal(signal.SIGINT)
+def disable_keyboard_interrupts(should_hold: bool = True):
+    """
+    Temporarily disable keyboard interrupt signals.
+
+    Parameters:
+        should_hold (bool, optional): Whether the signal should be emitted when
+            being re-enabled. Defaults to True.
+    """
+    sig and sig.disable_signal(signal.SIGINT, should_hold)
 
 
 def enable_keyboard_interrupts():
+    """Re-enable keyboard interrupt signals."""
     sig and sig.enable_signal(signal.SIGINT)
 
 
 def keyboard_interrupt_disabled():
     return sig and sig.signal_disabled(signal.SIGINT)
-
-
-def keyboard_interrupt_pending():
-    return sig and sig.signal_pending(signal.SIGINT)
 
 
 def exec_usysconf():

--- a/pisi/operations/install.py
+++ b/pisi/operations/install.py
@@ -140,6 +140,8 @@ def install_pkg_names(packages, reinstall=False):
             operations.remove.remove_conflicting_packages(conflicts)
 
     # Install all the packages
+    ctx.disable_keyboard_interrupts()
+
     try:
         for path in paths:
             ctx.ui.info(
@@ -156,6 +158,8 @@ def install_pkg_names(packages, reinstall=False):
         raise e
     finally:
         ctx.exec_usysconf()
+
+    ctx.enable_keyboard_interrupts()
 
     return True
 

--- a/pisi/operations/install.py
+++ b/pisi/operations/install.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 import os
+import signal
 import sys
 import zipfile
 
@@ -14,6 +15,7 @@ import pisi.util as util
 import pisi.atomicoperations as atomicoperations
 import pisi.operations as operations
 import pisi.pgraph as pgraph
+import pisi.signalhandler as signalhandler
 import pisi.ui as ui
 import pisi.db
 
@@ -45,6 +47,7 @@ def install_pkg_names(packages, reinstall=False):
 
     installdb = pisi.db.installdb.InstallDB()
     packagedb = pisi.db.packagedb.PackageDB()
+    signal_handler = signalhandler.SignalHandler()
 
     packages = [str(package) for package in packages]  # FIXME: why do we still get unicode input here? :/ -- exa
 
@@ -141,7 +144,7 @@ def install_pkg_names(packages, reinstall=False):
 
     # Install all the packages
     ctx.ui.info(_("Disabling keyboard interrupts for file operations."))
-    ctx.disable_keyboard_interrupts()
+    signal_handler.disable_signal(signal.SIGINT)
 
     try:
         for path in paths:
@@ -159,8 +162,6 @@ def install_pkg_names(packages, reinstall=False):
         raise e
     finally:
         ctx.exec_usysconf()
-
-    ctx.enable_keyboard_interrupts()
 
     return True
 

--- a/pisi/operations/install.py
+++ b/pisi/operations/install.py
@@ -140,6 +140,7 @@ def install_pkg_names(packages, reinstall=False):
             operations.remove.remove_conflicting_packages(conflicts)
 
     # Install all the packages
+    ctx.ui.info(_("Disabling keyboard interrupts for file operations."))
     ctx.disable_keyboard_interrupts()
 
     try:

--- a/pisi/operations/remove.py
+++ b/pisi/operations/remove.py
@@ -119,6 +119,8 @@ in the respective order to satisfy dependencies:
     ctx.ui.notify(ui.packagestogo, order=order)
 
     # Remove the packages.
+    ctx.disable_keyboard_interrupts()
+
     try:
         for package in order:
             if installdb.has_package(package):
@@ -129,6 +131,10 @@ in the respective order to satisfy dependencies:
         raise e
     finally:
         ctx.exec_usysconf()
+
+    ctx.enable_keyboard_interrupts()
+
+    return True
 
 
 def remove_orphans(ignore_dep=False, ignore_safety=False):

--- a/pisi/operations/remove.py
+++ b/pisi/operations/remove.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2005-2011 TUBITAK/UEKAE, 2013-2017 Ikey Doherty, Solus Project
 # SPDX-License-Identifier: GPL-2.0-or-later
 
+import signal
 import sys
 
 from pisi import translate as _
@@ -9,6 +10,7 @@ import pisi
 import pisi.context as ctx
 import pisi.atomicoperations as atomicoperations
 import pisi.pgraph as pgraph
+import pisi.signalhandler as signalhandler
 import pisi.util as util
 import pisi.ui as ui
 import pisi.db
@@ -28,6 +30,7 @@ def remove(
 
     componentdb = pisi.db.componentdb.ComponentDB()
     installdb = pisi.db.installdb.InstallDB()
+    signal_handler = signalhandler.SignalHandler()
 
     should_ignore_safety = (not ctx.get_option("ignore_safety")
                             and not ctx.config.values.general.ignore_safety
@@ -120,7 +123,7 @@ in the respective order to satisfy dependencies:
 
     # Remove the packages.
     ctx.ui.info(_("Disabling keyboard interrupts for file operations."))
-    ctx.disable_keyboard_interrupts()
+    signal_handler.disable_signal(signal.SIGINT)
 
     try:
         for package in order:
@@ -132,8 +135,6 @@ in the respective order to satisfy dependencies:
         raise e
     finally:
         ctx.exec_usysconf()
-
-    ctx.enable_keyboard_interrupts()
 
     return True
 

--- a/pisi/operations/remove.py
+++ b/pisi/operations/remove.py
@@ -119,6 +119,7 @@ in the respective order to satisfy dependencies:
     ctx.ui.notify(ui.packagestogo, order=order)
 
     # Remove the packages.
+    ctx.ui.info(_("Disabling keyboard interrupts for file operations."))
     ctx.disable_keyboard_interrupts()
 
     try:

--- a/pisi/operations/upgrade.py
+++ b/pisi/operations/upgrade.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2005-2011 TUBITAK/UEKAE, 2013-2017 Ikey Doherty, Solus Project
 # SPDX-License-Identifier: GPL-2.0-or-later
 
+import signal
 import sys
 
 from ordered_set import OrderedSet as set
@@ -12,6 +13,7 @@ import pisi.context as ctx
 import pisi.pgraph as pgraph
 import pisi.atomicoperations as atomicoperations
 import pisi.operations as operations
+import pisi.signalhandler as signalhandler
 import pisi.util as util
 import pisi.db
 import pisi.blacklist
@@ -119,6 +121,7 @@ def upgrade(packages = [], repo = None):
     packagedb = pisi.db.packagedb.PackageDB()
     installdb = pisi.db.installdb.InstallDB()
     replaces = packagedb.get_replaces()
+    signal_handler = signalhandler.SignalHandler()
 
     if not packages:
         # if packages is empty, then upgrade all packages
@@ -230,7 +233,7 @@ def upgrade(packages = [], repo = None):
 
     # Install all the packages
     ctx.ui.info(_("Disabling keyboard interrupts for file operations."))
-    ctx.disable_keyboard_interrupts()
+    signal_handler.disable_signal(signal.SIGINT)
 
     try:
         for path in paths:
@@ -248,8 +251,6 @@ def upgrade(packages = [], repo = None):
         raise e
     finally:
         ctx.exec_usysconf()
-
-    ctx.enable_keyboard_interrupts()
 
     return True
 

--- a/pisi/operations/upgrade.py
+++ b/pisi/operations/upgrade.py
@@ -229,6 +229,7 @@ def upgrade(packages = [], repo = None):
     operations.remove.remove_obsoleted_packages()
 
     # Install all the packages
+    ctx.ui.info(_("Disabling keyboard interrupts for file operations."))
     ctx.disable_keyboard_interrupts()
 
     try:

--- a/pisi/operations/upgrade.py
+++ b/pisi/operations/upgrade.py
@@ -229,6 +229,8 @@ def upgrade(packages = [], repo = None):
     operations.remove.remove_obsoleted_packages()
 
     # Install all the packages
+    ctx.disable_keyboard_interrupts()
+
     try:
         for path in paths:
             ctx.ui.info(
@@ -245,6 +247,10 @@ def upgrade(packages = [], repo = None):
         raise e
     finally:
         ctx.exec_usysconf()
+
+    ctx.enable_keyboard_interrupts()
+
+    return True
 
 
 def plan_upgrade(A, force_replaced=True, replaces=None):

--- a/pisi/signalhandler.py
+++ b/pisi/signalhandler.py
@@ -3,43 +3,107 @@
 
 import signal
 
-exception = {signal.SIGINT: KeyboardInterrupt}
+class SignalWrapper:
+    """
+    Wraps a system signal, keeping track of the original signal
+    handler, whether we have pending signal calls, and if we should
+    hold pending signals to emit later.
 
+    Attributes:
+        signal (signal.Signals): The signal being wrapped.
+        should_hold (bool): Whether we should hold pending signals.
+        old_handler (signal.Handlers): The original signal handler.
+        pending (bool): Whether there are signals pending.
+    """
 
-class Signal:
-    def __init__(self, sig):
+    def __init__(self, sig: signal.Signals, should_hold: bool):
+        """
+        Create a new SignalWrapper instance.
+
+        Parameters:
+            sig (signal.Signals): The signal to wrap.
+            should_hold (bool): Whether we should hold pending signals.
+        """
         self.signal = sig
-        self.oldhandler = signal.getsignal(sig)
-        self.pending = False
-
+        self.should_hold: bool = should_hold
+        self.old_handler: signal.Handlers | None = signal.SIG_DFL
+        self.pending: bool = False
 
 class SignalHandler:
+    """
+    This class manages the disabling and enabling of system signals.
+    When a signal is disabled, the original handler is stored by our
+    handler so it can be restored when the signal becomes enabled.
+
+    Attributes:
+        signals (dict[signal.Signals, SignalWrapper]): Disabled signals
+            and their handlers.
+    """
+
     def __init__(self):
-        self.signals = {}
+        """Create a new SignalHandler instance."""
+        self.signals: dict[signal.Signals, SignalWrapper] = {}
 
-    def signal_handler(self, sig, frame):
-        signal.signal(sig, signal.SIG_IGN)
-        self.signals[sig].pending = True
+    def disable_signal(self, sig: signal.Signals, should_hold: bool):
+        """
+        Disables a system signal by setting the handler to our own signal
+        handler, storing the original handler in a dictionary.
 
-    def disable_signal(self, sig):
-        if sig not in list(self.signals.keys()):
-            self.signals[sig] = Signal(sig)
-            signal.signal(sig, self.signal_handler)
+        Parameters:
+            sig (signal.Signals): The signal to disable.
+            should_hold (bool): Whether the signal should be emitted when
+                re-enabled if the signal was received while disabled.
+        """
+        if sig not in self.signals:
+            wrapper = SignalWrapper(sig, should_hold)
+            wrapper.old_handler = signal.signal(sig, self.__handler)
+            self.signals[sig] = wrapper
 
-    def enable_signal(self, sig):
-        if sig in list(self.signals.keys()):
-            if self.signals[sig].oldhandler:
-                oldhandler = self.signals[sig].oldhandler
-            else:
-                oldhandler = signal.SIG_DFL
-            pending = self.signals[sig].pending
-            del self.signals[sig]
-            signal.signal(sig, oldhandler)
-            if pending:
-                raise exception[sig]
+    def enable_signal(self, sig: signal.Signals):
+        """
+        Enables a system signal, setting its handler to the original
+        handler, or the default handler if we don't have one stored.
 
-    def signal_disabled(self, sig):
-        return sig in list(self.signals.keys())
+        If our handler was set to hold pending signal calls, and we
+        received that signal while it was disabled, we will emit the
+        signal as a part of re-enabling.
 
-    def signal_pending(self, sig):
-        return self.signal_disabled(sig) and self.signals[sig].pending
+        Currently, only SIGINT (Keyboard Interrupt) is supported.
+
+        Parameters:
+            sig (signal.Signals): The signal to enable.
+        """
+        if not sig in self.signals:
+            return
+
+        wrapper = self.signals[sig]
+
+        signal.signal(sig, wrapper.old_handler)
+        del self.signals[sig]
+
+        if not wrapper.should_hold:
+            return
+
+        if not wrapper.pending:
+            return
+
+        if sig is signal.SIGINT:
+            raise KeyboardInterrupt
+
+    def signal_disabled(self, sig: signal.Signals) -> bool:
+        """
+        Check if a signal has been disabled.
+
+        Parameters:
+            sig (signal.Signals): The signal to check.
+
+        Returns:
+            bool: Whether the signal has been disabled.
+        """
+        return sig in self.signals
+
+    def __handler(self, sig: int | signal.Signals, frame):
+        wrapper = self.signals[sig]
+
+        if wrapper.should_hold:
+            wrapper.pending = True

--- a/pisi/signalhandler.py
+++ b/pisi/signalhandler.py
@@ -3,31 +3,27 @@
 
 import signal
 
+
 class SignalWrapper:
     """
     Wraps a system signal, keeping track of the original signal
-    handler, whether we have pending signal calls, and if we should
-    hold pending signals to emit later.
+    handler to restore when the signal is re-enabled.
 
     Attributes:
         signal (signal.Signals): The signal being wrapped.
-        should_hold (bool): Whether we should hold pending signals.
         old_handler (signal.Handlers): The original signal handler.
-        pending (bool): Whether there are signals pending.
     """
 
-    def __init__(self, sig: signal.Signals, should_hold: bool):
+    def __init__(self, sig: signal.Signals):
         """
         Create a new SignalWrapper instance.
 
         Parameters:
             sig (signal.Signals): The signal to wrap.
-            should_hold (bool): Whether we should hold pending signals.
         """
         self.signal = sig
-        self.should_hold: bool = should_hold
         self.old_handler: signal.Handlers | None = signal.SIG_DFL
-        self.pending: bool = False
+
 
 class SignalHandler:
     """
@@ -44,31 +40,23 @@ class SignalHandler:
         """Create a new SignalHandler instance."""
         self.signals: dict[signal.Signals, SignalWrapper] = {}
 
-    def disable_signal(self, sig: signal.Signals, should_hold: bool):
+    def disable_signal(self, sig: signal.Signals):
         """
         Disables a system signal by setting the handler to our own signal
         handler, storing the original handler in a dictionary.
 
         Parameters:
             sig (signal.Signals): The signal to disable.
-            should_hold (bool): Whether the signal should be emitted when
-                re-enabled if the signal was received while disabled.
         """
         if sig not in self.signals:
-            wrapper = SignalWrapper(sig, should_hold)
-            wrapper.old_handler = signal.signal(sig, self.__handler)
+            wrapper = SignalWrapper(sig)
+            wrapper.old_handler = signal.signal(sig, signal.SIG_IGN)
             self.signals[sig] = wrapper
 
     def enable_signal(self, sig: signal.Signals):
         """
         Enables a system signal, setting its handler to the original
         handler, or the default handler if we don't have one stored.
-
-        If our handler was set to hold pending signal calls, and we
-        received that signal while it was disabled, we will emit the
-        signal as a part of re-enabling.
-
-        Currently, only SIGINT (Keyboard Interrupt) is supported.
 
         Parameters:
             sig (signal.Signals): The signal to enable.
@@ -80,30 +68,3 @@ class SignalHandler:
 
         signal.signal(sig, wrapper.old_handler)
         del self.signals[sig]
-
-        if not wrapper.should_hold:
-            return
-
-        if not wrapper.pending:
-            return
-
-        if sig is signal.SIGINT:
-            raise KeyboardInterrupt
-
-    def signal_disabled(self, sig: signal.Signals) -> bool:
-        """
-        Check if a signal has been disabled.
-
-        Parameters:
-            sig (signal.Signals): The signal to check.
-
-        Returns:
-            bool: Whether the signal has been disabled.
-        """
-        return sig in self.signals
-
-    def __handler(self, sig: int | signal.Signals, frame):
-        wrapper = self.signals[sig]
-
-        if wrapper.should_hold:
-            wrapper.pending = True


### PR DESCRIPTION
## Summary

This refactors the Pisi signal handler to be easier to follow. I'm not actually sure it was ever working correctly before. I'm not sure if we really need or want to hold pending signals to emit later, but I kept that functionality, while providing a way to disable it.

As a part of this, we now disable keyboard interrupts (SIGINT) for more operations: rebuild-database, remove package, and update repos.

Fixes https://github.com/getsolus/eopkg/issues/141
Fixes https://github.com/getsolus/eopkg/issues/105


## Test Plan

- Run `./eopkg.py3 history`, hit Ctrl+C, and see that the interrupt message no longer prints.
- Run `./eopkg.py3 rdb`, hit Ctrl+C, and see that the process is not interrupted until the rebuild finishes.

More testing is definitely required, but the other operations usually happen too fast for me to actually interrupt them.
