### PR TITLE
db/packagedb: When getting pkgconfig providers reverse through repo list

### DIFF
--- a/pisi/db/packagedb.py
+++ b/pisi/db/packagedb.py
@@ -114,12 +114,16 @@ class PackageDB(lazydb.LazyDB):
             return (pkgConfigs, pkgConfigs32)
 
         if repo is None:
-            for repo in repodb.list_repos():
+            repos = repodb.list_repos()
+            # .reverse() doesn't work, so use the slice notation for reversing the non-empty list.
+            # This is necessary because we traverse the list in reverse order to solve the
+            # original problem, and now we need to reverse it back to the normal order
+            repos = repos[::-1] if repos is not None else None
+            for repo in repos:
                 doc = repodb.get_repo_doc(repo)
                 pkgConfig, pkgConfigs32 = map_providers(
                         doc, pkgConfigs, pkgConfigs32)
         else:
-            repodb = pisi.db.repodb.RepoDB()
             if repo not in repodb.list_repos(only_active=False):
                 raise Exception(_("Repo %s not found.") % repo)
             doc = repodb.get_repo_doc(repo)


### PR DESCRIPTION
## Summary

Currently, repo priority is basically implied throughout the pisi codebase unfortunately. However, trawling through the repo list in reverse we ensure that we return the correct pkgconfig provider for the highest priority repo.
    
E.g. repo A and B provide pkgconfig(foo), in repo A pkgconfig(foo) is provided by foo1 and in repo B pkgconfig(foo) is provided by foo2. If repo B has a higher repo priority than repo A then we want to ensure we return the package foo2. As it's a dict where there can only be one unique key by trawling in reverse we override it by getting the pkgconfig from the higher priority repo.
    
This fixes issues in packaging with local repos where pkgconfigs move between packages.
    
Resolves #153.
    
This PR also removes a useless repodb redeclaration that was introduced in the previous PR.

## Test Plan

Scenario: we want to update `libgeocode-glib` to the version used in `libgeocode-glib2` as nothing depends on `libgeocode-glib` any longer, so we can deprecate `libgeocode-glib2` and move all dependencies to `libgeocode-glib` to ensure clean packaging names.

`libgeocode-glib-devel` in the Local repo now provides `pkgconfig(geocode-glib-2.0)` instead of `pkgconfig(geocode-glib-1.0)`
`libgeocode-glib2-devel` in the Unstable repo provides `pkgconfig(geocode-glib-2.0)`

When building against the Local repo we want to ensure `libgeocode-glib-devel` is installed not `libgeocode-glib2-devel`

Before
```python
>>> import pisi
>>> pdb = pisi.db.packagedb.PackageDB()
>>> pc, pc32 = pdb.get_pkgconfig_providers()
>>> for k, v in pc.items():
...     if "geocode-glib" in v:
...             print(k, v)
... 
geocode-glib-2.0 libgeocode-glib2-devel
geocode-glib-1.0 libgeocode-glib-devel
```

Now
```python
>>> import pisi
>>> pdb = pisi.db.packagedb.PackageDB()
>>> pc, pc32 = pdb.get_pkgconfig_providers()
>>> for k, v in pc.items():
...     if "geocode-glib" in v:
...             print(k, v)
... 
geocode-glib-1.0 libgeocode-glib-devel
geocode-glib-2.0 libgeocode-glib-devel
```

If we only match against the Unstable repo then `libgeocode-glib2-devel` provides `geocode-glib-2.0` instead of `libgeocode-glib-devel`
```python
>>> import pisi
>>> pdb = pisi.db.packagedb.PackageDB()
>>> pc, pc32 = pdb.get_pkgconfig_providers('Unstable')
>>> for k, v in pc.items():
...     if "geocode-glib" in v:
...             print(k, v)
... 
geocode-glib-1.0 libgeocode-glib-devel
geocode-glib-2.0 libgeocode-glib2-devel
```
