### PR TITLE
`pisi.command`: Re-exec with pkcon if not already root when running privileged operations

### DIFF
--- a/pisi/cli/command.py
+++ b/pisi/cli/command.py
@@ -177,7 +177,10 @@ class Command(object):
             ui = pisi.cli.CLI()
 
         if write and not os.access(pisi.context.config.packages_dir(), os.W_OK):
-            raise pisi.cli.Error(_("You have to be root for this operation."))
+            try:
+                os.execv('/usr/bin/pkexec',  ['/usr/bin/pkexec', ] + sys.argv)
+            except:
+                raise pisi.cli.Error(_("You have to be root for this operation."))
 
         pisi.api.set_userinterface(ui)
         pisi.api.set_options(self.options)


### PR DESCRIPTION
## Summary
Previously, attempting a privileged operation (install, etc.) without already having root access resulted in an error. This PR adds code which re-executes the current command using `pkcon` to provide a nice password prompt instead.

I am really not sure this is the right and proper way to accomplish the desired outcome. It seems to me like "the done thing" according to the docs is to implement some sort of dbus service which runs as root, and then use polkit to control access thereto. I am not experienced in the magic of dbus, though, so I've written this the possibly-too-lazy way just to see what others think. This may need further work.

TL;DR: Fulfilled the feature request, possibly in a stupid way. Tell me if I'm wrong.

Fixes #120.

## Test Plan
1. Check out this PR. 
2. Run `./eopkg.py3 install <some package>. Note that you get a pkcon password prompt, and that after a successful authorization, `eopkg` continues in your terminal.