### PR TITLE
pisi.util: Fix broken DBus error handling

### DIFF
--- a/pisi/api.py
+++ b/pisi/api.py
@@ -70,6 +70,10 @@ def locked(func):
         inhibit_fd = None
         inhibit_file = None
         conn, inhibit_fd = pisi.util.systemd_inhibit(reason)
+        print('API wrapper: conn and inhibit_fd contents, then types.')
+        print(conn, inhibit_fd)
+        print('API wrapper: conn and inhibit_fd types.')
+        print(type(conn), type(inhibit_fd))
         if inhibit_fd is not None:
             inhibit_file = inhibit_fd.to_file("wb")
 

--- a/pisi/api.py
+++ b/pisi/api.py
@@ -70,10 +70,6 @@ def locked(func):
         inhibit_fd = None
         inhibit_file = None
         conn, inhibit_fd = pisi.util.systemd_inhibit(reason)
-        print('API wrapper: conn and inhibit_fd contents, then types.')
-        print(conn, inhibit_fd)
-        print('API wrapper: conn and inhibit_fd types.')
-        print(type(conn), type(inhibit_fd))
         if inhibit_fd is not None:
             inhibit_file = inhibit_fd.to_file("wb")
 

--- a/pisi/util.py
+++ b/pisi/util.py
@@ -980,6 +980,8 @@ def systemd_inhibit(reason: str):
 
         # Call and receive the file descriptor
         reply = conn.send_and_get_reply(msg)
+        print('Message Type!!')
+        print(reply.header.message_type)
 
         if isinstance(reply, DBusErrorResponse):
             ctx.ui.warning(_("Failed to acquire inhibit lock %s" % reply.error_name))

--- a/pisi/util.py
+++ b/pisi/util.py
@@ -18,6 +18,8 @@ import operator
 import subprocess
 import unicodedata
 
+from jeepney import MessageType
+
 from pisi import translate as _
 from functools import reduce
 
@@ -983,8 +985,8 @@ def systemd_inhibit(reason: str):
         print('Message Type!!')
         print(reply.header.message_type)
 
-        if isinstance(reply, DBusErrorResponse):
-            ctx.ui.warning(_("Failed to acquire inhibit lock %s" % reply.error_name))
+        if reply.header.message_type != MessageType.method_return:
+            ctx.ui.warning(_("Failed to acquire inhibit lock: %s" % reply.body))
             return None, None
 
         # Extract the file descriptor

--- a/pisi/util.py
+++ b/pisi/util.py
@@ -982,8 +982,6 @@ def systemd_inhibit(reason: str):
 
         # Call and receive the file descriptor
         reply = conn.send_and_get_reply(msg)
-        print('Message Type!!')
-        print(reply.header.message_type)
 
         if reply.header.message_type != MessageType.method_return:
             ctx.ui.warning(_("Failed to acquire inhibit lock: %s" % reply.body))


### PR DESCRIPTION
## Summary
Checks for DBus errors correctly when attempting to inhibit system suspend/shutdown. This prevents a nasty crash when running in solbuild.

## Test Plan
- Set up an eopkg package.yml to use the last commit SHA on this branch.
- Build that, copying to the local repo.
- Build something else with the local repo.
- Note that eopkg (unlike v4.3.0) does not crash and kill solbuild with it.