### PR TITLE
pisi.util: Fix import in the wrong place, remove unnecessary import

### DIFF
--- a/pisi/util.py
+++ b/pisi/util.py
@@ -18,8 +18,6 @@ import operator
 import subprocess
 import unicodedata
 
-from jeepney import MessageType
-
 from pisi import translate as _
 from functools import reduce
 
@@ -961,7 +959,7 @@ def letters():
 
 # https://www.freedesktop.org/software/systemd/man/latest/systemd-inhibit.html
 def systemd_inhibit(reason: str):
-    from jeepney import DBusAddress, DBusErrorResponse, new_method_call
+    from jeepney import DBusAddress, MessageType, new_method_call
     from jeepney.io.blocking import open_dbus_connection
 
     try:


### PR DESCRIPTION
## Summary
Fixes a misplaced import introduced in #170.

## Test Plan
1. Remove `python-jeepney` from your system.
2. Ensure your system is fully updated, running `python-eopkg` rel 26.
3. Try `lseopkg <some-eopkg-file>`.
4. Note the failure to import `jeepney`.
5. Create a venv in your clone of this repository with this PR checked out. Make sure that `jeepney` is not installed in the venv (`pip uninstall jeepney`).
6. Try `./pisi/scripts/lseopkg.py <some-eopkg-file>` and note that it works.

Partially fixes https://github.com/getsolus/packages/issues/6165. 