### PR TITLE
pisi.archive.ArchiveTar.unpack_dir: Remove directories first when they will be replaced with regular files

### DIFF
--- a/pisi/archive.py
+++ b/pisi/archive.py
@@ -385,6 +385,11 @@ class ArchiveTar(ArchiveBase):
                         # If fails, try to remove it
                         shutil.rmtree(tarinfo.name)
 
+            elif os.path.isdir(tarinfo.name) and tarinfo.isfile():
+                # If we get past all of the above and the destination is still a directory and the new package is
+                # installing a regular file there, remove the directory first. The tarfile module cannot handle this.
+                shutil.rmtree(tarinfo.name)
+
             try:
                 self.tar.extract(tarinfo)
             except (IOError, OSError) as e:


### PR DESCRIPTION
## Summary
The `tarfile` module is not capable of handling the (rare) case when a directory is replaced with an identically-named file. We already handle this case specifically for symlinks, but not for regular files. This PR adds a path to deal with that situation.

Fixes #98.

## Test Plan
I tested this (out of sheer convenience) using the most recent instance of the issue being solved (which was upgrading `lsfg-vk` from rel 2 to rel 3), but the instructions to reproduce #98 are a perfectly good test plan for this as well. Just replace `eopkg` with `./eopkg.py3` after checking out this PR. 