### PR TITLE
pyproject.toml: Add ordered_set to build requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ uneopkg = "pisi.scripts.uneopkg:main"
 # Builder-specific keys below. We use setuptools.
 
 [build-system]
-requires = ["setuptools>=58.0", "iksemel>=1.6.1", "python-magic>=0.4.27"]
+requires = ["setuptools>=58.0", "iksemel>=1.6.1", "python-magic>=0.4.27", "ordered_set>=4.1.0,<=4.2.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
## Summary
Adds `ordered_set` to build deps.

## Test Plan

1. Attempt to build an `eopkg` wheel (I did it with `pip install .`).
2. Notice that it doesn't work.
3. Check out this PR.
4. `pip install .`.
5. It works!