### PR TITLE
pyproject: Add ordered_set to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [{ name = "Solus Project", email = "releng@getsol.us" }]
 keywords = ["package", "manager", "management", "solus"]
 classifiers = ["Programming Language :: Python :: 3 :: Only"]
 requires-python = ">=3.8.0"
-dependencies = ["iksemel>=1.6.1", "python-magic>=0.4.27", "xattr>= 1.1.0"]
+dependencies = ["iksemel>=1.6.1", "ordered_set>=4.1.0,<=4.2.0", "python-magic>=0.4.27", "xattr>= 1.1.0"]
 dynamic = ["version"]
 
 [project.urls]


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/getsolus/eopkg/pull/182

## Test Plan

Install `ypkg` and `eopkg` in a venv and run `ypkg` without an error about `ordered_set` missing.
