### PR TITLE
i18n: Improve how localization is set up

### DIFF
--- a/pisi/__init__.py
+++ b/pisi/__init__.py
@@ -16,7 +16,11 @@ from importlib.resources import files
 import pisi.signalhandler as signalhandler
 
 
-locale.setlocale(locale.LC_ALL, "")
+try:
+    locale.setlocale(locale.LC_ALL, "")
+except locale.Error as e:
+    print(f"Unable to set locale: {e}")
+    print("")
 
 _localeres = files("pisi.data").joinpath("locale")
 if _localeres.is_dir():
@@ -24,7 +28,7 @@ if _localeres.is_dir():
 else:
     _localedir = None  # Use the system one.
 
-lang_code = [locale.getlocale()[0] or 'en_US']
+lang_code = [locale.getlocale()[0] or "en_US"]
 lang = gettext.translation(
     "pisi", localedir=_localedir, fallback=True, languages=lang_code
 )


### PR DESCRIPTION
## Summary

If an invalid locale is set, `locale.setlocale()` throws an exception. This change catches the exception and prints a message instead of exiting with a stacktrace. Whether or not this will have side effects, I have no idea.

Fixes https://github.com/getsolus/eopkg/issues/186

## Test Plan

1. Run `./eopkg.py3 info pisi`
2. Run `LANG=es_ES ./eopkg.py3 info pisi`
3. Run `LC_TIME=en_DE ./eopkg.py3 info pisi`
