### PR TITLE
pisi.api, pisi.operations.build: Fix SyntaxWarning in regex strings

### DIFF
--- a/pisi/api.py
+++ b/pisi/api.py
@@ -829,7 +829,7 @@ def index(dirs=None, output="eopkg-index.xml", skip_signing=False, compression=0
 
 @locked
 def add_repo(name, indexuri, at=None):
-    if not re.match("^[0-9%s\-\\_\\.\s]*$" % str(pisi.util.letters()), name):
+    if not re.match(r"^[0-9%s\-\\_\\.\s]*$" % str(pisi.util.letters()), name):
         raise pisi.Error(_("Not a valid repo name."))
     repodb = pisi.db.repodb.RepoDB()
 

--- a/pisi/operations/build.py
+++ b/pisi/operations/build.py
@@ -132,9 +132,9 @@ def exclude_special_files(filepath, fileinfo, ag):
         # patches, eopkg removes wrong paths...
         if re.match(patterns["libtool"], fileinfo) and not os.path.islink(filepath):
             ladata = open(filepath).read()
-            new_ladata = re.sub("-L%s/\S*" % ctx.config.tmp_dir(), "", ladata)
+            new_ladata = re.sub(r"-L%s/\S*" % ctx.config.tmp_dir(), "", ladata)
             new_ladata = re.sub(
-                "%s/\S*/install/" % ctx.config.tmp_dir(), "/", new_ladata
+                r"%s/\S*/install/" % ctx.config.tmp_dir(), "/", new_ladata
             )
             if new_ladata != ladata:
                 open(filepath, "w").write(new_ladata)


### PR DESCRIPTION
## Summary
As of Python 3.12, SyntaxWarnings are emitted for invalid escape sequences in strings. Regex strings are not regular strings, though. In modern python, they should be stored as raw strings (`r"..."`) to avoid warnings showing up when the program is run. This PR changes known instances of regex strings to stop warnings reported in the comments of #187.

## Test Plan
Tested `eopkg add-repo`. It still works!
Did not test `eopkg build`. Might be a good idea.

No idea what the regex actually does. I do not have a [regex license](https://regexlicensing.org/), so all I can do is fix the python syntax ;)