### PR TITLE
repodb: When no repositories are configured, add polaris instead of shannon

### DIFF
--- a/pisi/db/repodb.py
+++ b/pisi/db/repodb.py
@@ -169,7 +169,7 @@ class RepoDB(lazydb.LazyDB):
 
         if len(self.repoorder.repos) == 0:
             repo = pisi.db.repodb.Repo(
-                pisi.uri.URI("https://cdn.getsol.us/repo/shannon/eopkg-index.xml.xz")
+                pisi.uri.URI("https://cdn.getsol.us/repo/polaris/eopkg-index.xml.xz")
             )
             ctx.ui.warning("No repository found. Automatically adding Solus stable.")
             self.add_repo("Solus", repo, ctx.get_option("at"))


### PR DESCRIPTION
## Summary
Makes eopkg auto-add Polaris instead of Shannon when there are no repositories.

## Test Plan
- Removed all my repos.
- Tried to remove the last one twice.
- Got a message saying Solus stable was automatically added.
- It was.