### PR TITLE
addrepo.py: Raise an error when adding a broken repo

### DIFF
--- a/pisi/cli/addrepo.py
+++ b/pisi/cli/addrepo.py
@@ -54,10 +54,6 @@ NB: We support only local files (e.g., /a/b/c) and http:// URIs at the moment
         )
         self.parser.add_option_group(group)
 
-    def warn_and_remove(self, message, repo):
-        ctx.ui.warning(message)
-        pisi.api.remove_repo(repo)
-
     def run(self):
         if len(self.args) == 2:
             self.init()


### PR DESCRIPTION
## Summary
Adding a repository that doesn't work should definitely result in an error instead of a warning, especially since the current behavior causes annoyance for the epoch script. This PR makes eopkg's CLI more consistent by raising an error instead of a warning.

This PR also streamlines the code in addrepo.py, removing the `warn_and_remove` method which was only ever used here. It's only 2 lines and only made the code more confusing. 

## Test Plan
- Note that `./eopkg.py3 ar Nope https://invalid.nope` results in a warning and a return code of 0.
- Check out this PR.
- Note that `./eopkg.py3 ar Nope https://invalid.nope` results in an error and a return code of 1.
- Note that adding a real repository still works.