### PR TITLE
Add support for managing appstream catalogs as part of the index

### DIFF
--- a/pisi/api.py
+++ b/pisi/api.py
@@ -21,6 +21,7 @@ import pisi.db.installdb
 import pisi.db.historydb
 import pisi.db.componentdb
 import pisi.db.groupdb
+import pisi.db.appstreamdb
 import pisi.index
 import pisi.config
 import pisi.metadata
@@ -35,6 +36,7 @@ import pisi.operations.helper
 import pisi.operations.check
 import pisi.operations.build
 import pisi.signalhandler as signalhandler
+import pisi.operations.appstream
 import pisi.errors
 
 
@@ -901,6 +903,7 @@ def __update_repo(repo, force=False):
     index = pisi.index.Index()
     if repodb.has_repo(repo):
         repouri = repodb.get_repo(repo).indexuri.get_uri()
+        pisi.operations.appstream.update_catalogs(repo, force)
         try:
             index.read_uri_of_repo(repouri, repo)
         except pisi.file.AlreadyHaveException as e:

--- a/pisi/appstream.py
+++ b/pisi/appstream.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2005-2011 TUBITAK/UEKAE, 2013-2017 Ikey Doherty, Solus Project
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+import pisi
+import pisi.pxml.xmlfile as xmlfile
+import pisi.pxml.autoxml as autoxml
+
+
+class Error(pisi.Error):
+    pass
+
+
+class Icons(xmlfile.XmlFile, metaclass=autoxml.autoxml):
+
+    a_size = [autoxml.String, autoxml.MANDATORY]
+    t_URI = [autoxml.String, autoxml.MANDATORY]
+
+
+class AppstreamCatalog(xmlfile.XmlFile, metaclass=autoxml.autoxml):
+    "representation for appstream declarations"
+
+    t_Origin = [autoxml.String, autoxml.MANDATORY]
+    t_URI = [autoxml.String, autoxml.MANDATORY]
+    t_Icons = [[Icons], autoxml.OPTIONAL, "Icons"]
+
+
+class AppstreamCatalogs(xmlfile.XmlFile, metaclass=autoxml.autoxml):
+    "representation for component declarations"
+
+    tag = "PISI"
+
+    t_Appstreams = [[AppstreamCatalog], autoxml.MANDATORY, "AppstreamCatalogs/AppstreamCatalog"]

--- a/pisi/db/appstreamdb.py
+++ b/pisi/db/appstreamdb.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2005-2011 TUBITAK/UEKAE, 2013-2017 Ikey Doherty, Solus Project
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+import pisi
+import pisi.appstream
+import pisi.db
+import pisi.db.itembyrepo
+from pisi import translate as _
+from pisi.db import lazydb
+
+
+class AppstreamNotFound(Exception):
+    pass
+
+
+class AppstreamDB(lazydb.LazyDB):
+    def __init__(self):
+        lazydb.LazyDB.__init__(self, cacheable=False)
+
+    def init(self):
+        catalog_nodes = {}
+        catalog_components = {}
+
+        repodb = pisi.db.repodb.RepoDB()
+
+        for repo in repodb.list_repos():
+            doc = repodb.get_repo_doc(repo)
+            catalog_nodes[repo] = self.__generate_catalogs(doc)
+            catalog_components[repo] = self.__generate_single_catalog(doc)
+
+        self.adb = pisi.db.itembyrepo.ItemByRepo(catalog_nodes)
+        self.acdb = pisi.db.itembyrepo.ItemByRepo(catalog_components)
+
+    def __generate_single_catalog(self, doc):
+        catalogs = {}
+        for c in doc.tags("AppstreamCatalog"):
+            catalog = c.getTagData("Origin") or "unknown"
+            catalog_info = {
+                "uri": c.getTagData("URI"),
+                "icons_sizes": [x.getAttribute("size") for x in c.tags("Icons")],
+                "icon_urls": [x.getTagData("URI") for x in c.tags("Icons")],
+            }
+            catalogs.setdefault(catalog, []).append(catalog_info)
+        return catalogs
+
+    def __generate_catalogs(self, doc):
+        return dict(
+            [
+                (x.getTagData("Origin"), x.toString())
+                for x in doc.tags("AppstreamCatalog")
+            ]
+        )
+
+    def has_catalog(self, name, repo=None):
+        return self.adb.has_item(name, repo)
+
+    def list_catalogs(self, repo=None):
+        return self.adb.get_item_keys(repo)
+
+    def get_catalog(self, name, repo=None):
+        if not self.has_catalog(name, repo):
+            raise AppstreamNotFound(_(f"Appstream catalog {name} not found"))
+
+        catalog = pisi.appstream.AppstreamCatalog()
+        catalog.parse(self.adb.get_item(name, repo))
+
+        return catalog
+
+    def get_catalog_components(self, name, repo=None):
+        if not self.has_catalog(name, repo):
+            raise AppstreamNotFound(_(f"Appstream catalog {name} not found"))
+
+        if self.acdb.has_item(name):
+            return self.acdb.get_item(name, repo)
+
+        return []

--- a/pisi/index.py
+++ b/pisi/index.py
@@ -3,24 +3,24 @@
 
 """eopkg source/package index"""
 
+import multiprocessing
 import os
 import shutil
-import multiprocessing
-
-from pisi import translate as _
 
 import pisi
-import pisi.context as ctx
-import pisi.specfile as specfile
-import pisi.metadata as metadata
-import pisi.util as util
-import pisi.package
-import pisi.pxml.xmlfile as xmlfile
-import pisi.file
-import pisi.pxml.autoxml as autoxml
+import pisi.appstream as appstream
 import pisi.component as component
+import pisi.context as ctx
+import pisi.file
 import pisi.group as group
+import pisi.metadata as metadata
 import pisi.operations.build
+import pisi.package
+import pisi.pxml.autoxml as autoxml
+import pisi.pxml.xmlfile as xmlfile
+import pisi.specfile as specfile
+import pisi.util as util
+from pisi import translate as _
 
 
 class Error(pisi.Error):
@@ -36,6 +36,7 @@ class Index(xmlfile.XmlFile, metaclass=autoxml.autoxml):
     # t_Metadatas = [ [metadata.MetaData], autoxml.optional, "MetaData"]
     t_Components = [[component.Component], autoxml.OPTIONAL, "Component"]
     t_Groups = [[group.Group], autoxml.OPTIONAL, "Group"]
+    t_Appstreams = [[appstream.AppstreamCatalog], autoxml.OPTIONAL, "AppstreamCatalog"]
 
     def read_uri(self, uri, tmpdir, force=False):
         return self.read(
@@ -97,6 +98,8 @@ class Index(xmlfile.XmlFile, metaclass=autoxml.autoxml):
                 elif fn.endswith(ctx.const.package_suffix):
                     packages.append(os.path.join(root, fn))
 
+                if fn == "appstream.xml":
+                    self.appstreams.extend(add_appstreams(os.path.join(root, fn)))
                 if fn == "components.xml":
                     self.components.extend(add_components(os.path.join(root, fn)))
                 if fn == "distribution.xml":
@@ -169,7 +172,8 @@ def add_package(params):
             ctx.ui.info("  %s" % os.path.basename(path))
         else:
             ctx.ui.info(
-                "%-80.80s\r" % (_("Adding package to index: %s") % os.path.basename(path)),
+                "%-80.80s\r"
+                % (_("Adding package to index: %s") % os.path.basename(path)),
                 noln=True,
             )
 
@@ -238,6 +242,13 @@ def add_package(params):
         # KeyboardInterrupt exception as an Exception.
 
         raise Exception
+
+
+def add_appstreams(path):
+    ctx.ui.info(_("Adding appstream.xml to index"))
+    appstreams_xml = appstream.AppstreamCatalogs()
+    appstreams_xml.read(path)
+    return appstreams_xml.appstreams
 
 
 def add_groups(path):

--- a/pisi/operations/appstream.py
+++ b/pisi/operations/appstream.py
@@ -1,0 +1,214 @@
+# SPDX-FileCopyrightText: 2005-2011 TUBITAK/UEKAE, 2013-2017 Ikey Doherty, Solus Project
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+import email.utils
+import gzip
+import os
+import posixpath
+import xml.etree.ElementTree as ET
+from contextlib import contextmanager
+from email.utils import formatdate
+from pathlib import Path
+from urllib.parse import urlparse
+
+import lzma_mt
+
+import pisi.context as ctx
+import pisi.db
+import pisi.db.appstreamdb
+import pisi.fetcher as fetcher
+import pisi.uri
+import pisi.util
+from pisi import appstream
+from pisi import translate as _
+from pisi.archive import ArchiveTar
+from pisi.db.appstreamdb import AppstreamNotFound
+
+# https://www.freedesktop.org/software/appstream/docs/chap-CatalogData.html#sect-AppStream-XML
+
+CATALOG_BASE_PATH = "/var/lib/swcatalog"
+CATALOG_XML_PATH = os.path.join(CATALOG_BASE_PATH, "xml")
+CATALOG_ICONS_BASE_PATH = os.path.join(CATALOG_BASE_PATH, "icons")
+
+
+def __appstream_get_catalog_origin(file_path):
+    """Returns the 'origin' of the compressed or uncompressed appstream catalog XML file"""
+    with __read_appstream_catalog(file_path) as f:
+        tree = ET.parse(f)
+        root = tree.getroot()
+
+        if root.tag == "components":
+            return root.attrib.get("origin")
+        else:
+            raise ValueError("Root tag is not 'components'")
+
+
+@contextmanager
+def __read_appstream_catalog(file_path):
+    valid_extensions = (".xml", ".xml.gz", ".xml.xz")
+
+    if not file_path.endswith(valid_extensions):
+        raise ValueError(f"Unsupported appstream catalog extension: {file_path}")
+
+    def open_file(path):
+        if path.endswith(".gz"):
+            return gzip.open(path, "rt", encoding="utf-8")
+        elif path.endswith(".xz"):
+            return lzma_mt.open(path, "rt", encoding="utf-8")
+        else:
+            return open(path, "rt", encoding="utf-8")
+
+    f = open_file(file_path)
+    try:
+        yield f
+    finally:
+        f.close()
+
+
+def __get_last_modified_http_header(file_path):
+    # Get last modified time as seconds since epoch
+    mtime = os.path.getmtime(file_path)
+
+    # Convert to RFC 1123 formatted date in GMT
+    http_date = formatdate(timeval=mtime, usegmt=True)
+
+    return http_date
+
+
+def __get_full_extension(uri):
+    path = urlparse(uri).path
+    basename = os.path.basename(path)
+    parts = basename.split(".")
+    if len(parts) > 1:
+        return "." + ".".join(parts[1:])
+    return ""
+
+
+def __download_appstream_catalog(catalog: appstream.AppstreamCatalog, force=False):
+    catalog_uri = pisi.uri.URI(catalog.uRI)
+    full_ext = __get_full_extension(catalog.uRI)
+    pisi.util.ensure_dirs(CATALOG_XML_PATH)
+    existing = os.path.join(CATALOG_XML_PATH, f"{catalog.origin}{full_ext}")
+
+    existing_last_mod = None
+    if os.path.exists(existing):
+        existing_last_mod = __get_last_modified_http_header(existing)
+
+    fetch = fetcher.fetch_url(
+        catalog.uRI,
+        CATALOG_XML_PATH,
+        ctx.ui.Progress,
+        destfile=existing,
+        headers_only=True,
+    )
+
+    if force is False and (fetch.headers.get("Last-Modified") == existing_last_mod):
+        ctx.ui.debug(
+            _("Appstream: 'Last-Modified' is identical, skipping %s")
+            % catalog_uri.get_uri()
+        )
+        return
+
+    fetch.headers_only = False
+    fetch.fetch()
+
+    # Restore modified time to match URI
+    mod_time = email.utils.parsedate_to_datetime(
+        fetch.headers.get("Last-Modified")
+    ).timestamp()
+    os.utime(existing, (mod_time, mod_time))
+
+    origin = __appstream_get_catalog_origin(existing)
+    if origin != catalog.origin:
+        raise AppstreamNotFound(
+            _(
+                f"Appstream catalog origin doesn't match, expected: {catalog.origin}, actual: {origin}"
+            )
+        )
+
+    # Create a marker so we know this catalog is managed by eopkg
+    existing_marker = Path(f"{existing}.eopkg")
+    if not os.path.exists(existing_marker):
+        existing_marker.touch()
+
+    if catalog.icons is None:
+        return
+    __download_appstream_icons(catalog, origin, force)
+
+
+def __download_appstream_icons(
+    catalog: appstream.AppstreamCatalog, origin: str, force=False
+):
+    for icons in catalog.icons:
+        target_dir = os.path.join(CATALOG_ICONS_BASE_PATH, origin, icons.size)
+        pisi.util.ensure_dirs(target_dir)
+        existing_last_mod = __get_last_modified_http_header(target_dir)
+        icons_uri = pisi.uri.URI(icons.uRI)
+        tmpfile = pisi.util.join_path("/tmp", icons_uri.filename())
+        fetch = fetcher.fetch_url(
+            icons.uRI, "/tmp", ctx.ui.Progress, destfile=tmpfile, headers_only=True
+        )
+
+        if force is False and (fetch.headers.get("Last-Modified") == existing_last_mod):
+            ctx.ui.debug(
+                _(f"Appstream: 'Last-Modified' is identical, skipping {catalog.uRI}")
+            )
+            continue
+
+        fetch.headers_only = False
+        fetch.fetch()
+
+        icons_archive = ArchiveTar(tmpfile, "targz")
+        icons_archive.unpack(target_dir)
+
+        # Restore modified time to match URI
+        mod_time = email.utils.parsedate_to_datetime(
+            fetch.headers.get("Last-Modified")
+        ).timestamp()
+        os.utime(target_dir, (mod_time, mod_time))
+
+
+def __get_obsolete_catalogs(appstreams: list):
+    path = Path(CATALOG_XML_PATH)
+    if path.exists() is False:
+        return
+
+    installed_catalogs = {path / f.name for f in path.iterdir() if f.is_file()}
+    eopkg_managed = set()
+
+    for catalog in installed_catalogs:
+        if not os.path.exists(f"{catalog}.eopkg"):
+            continue
+        eopkg_managed.add(catalog)
+
+    obsolete = {
+        posixpath.basename(f)[: -sum(len(s) for s in f.suffixes)] for f in eopkg_managed
+    } - {origin for origin in appstreams}
+
+    if obsolete:
+        ctx.ui.debug(_(f"Appstream: Obsolete catalogs marked for removal: {obsolete}"))
+    return obsolete
+
+
+def __remove_obsolete_catalog(catalog):
+    xml_pattern = os.path.join(CATALOG_XML_PATH, catalog)
+    icon_pattern = os.path.join(CATALOG_ICONS_BASE_PATH, catalog)
+    pisi.util.nuke_dir_recursive_glob(xml_pattern)
+    pisi.util.nuke_dir_recursive_glob(icon_pattern)
+    ctx.ui.debug(_(f"Appstream: Removed obsolete catalog '{catalog}'"))
+
+
+def update_catalogs(repo, force=False):
+    appstreamdb = pisi.db.appstreamdb.AppstreamDB()
+    catalogs = appstreamdb.list_catalogs(repo)
+    obsoletes = __get_obsolete_catalogs(catalogs)
+    # A repo may have more than one appstream catalog and add/drop usage of
+    # catalogs at will, so we have to do a nasty obsoletes check. I can't think
+    # of a better way to do this right now.
+    if obsoletes:
+        for catalog in obsoletes:
+            __remove_obsolete_catalog(catalog)
+    if catalogs is not None:
+        for origin in catalogs:
+            catalog = appstreamdb.get_catalog(origin)
+            __download_appstream_catalog(catalog, force)

--- a/pisi/util.py
+++ b/pisi/util.py
@@ -359,6 +359,20 @@ def clean_dir(path):
         shutil.rmtree(path)
 
 
+def nuke_dir_recursive_glob(pattern):
+    """Remove a directory recursively matching a glob e.g. rm -fr foo*"""
+    import glob
+    pattern = f"{pattern}*"
+    for path in glob.glob(pattern):
+        try:
+            if os.path.isdir(path) and not os.path.islink(path):
+                shutil.rmtree(path)
+            else:
+                os.remove(path)
+        except Exception as e:
+            print(f"Error removing {path}: {e}")
+
+
 def creation_time(_file):
     """Return the creation time of the given file."""
     if check_file(_file):


### PR DESCRIPTION
## Summary

### Why

We want up-to-date appstream catalog information as some applications contain changelog information in their appstream metadata. This changelog information is then shown in front-ends such as gnome-software. As is it currently, appstream-catalog is downloaded as part of a separate package, this then means that gnome-software will show out of date changelog information for packages. e.g. an update to gnome-clocks 49.0 exists and the changelog for this release is included an update for appstream-catalog. However, as the latest appstream-catalog is not yet installed gnome-software will either show out of date changelog information or simply fall back to the generic summary message used for the update. By updating the appstream-catalog as part of the eopkg index we can then ensure we always have the most up-to-date changelog information for available updates.

#### Example

Before up-to-date appstream catalog is installed:
<img width="1699" height="971" alt="Screenshot From 2025-11-11 12-30-55" src="https://github.com/user-attachments/assets/2a40807b-22ee-490f-849d-8de27ac9c902" />

After up-to-date appstream catalog is installed:
<img width="1699" height="971" alt="Screenshot From 2025-11-11 12-32-05" src="https://github.com/user-attachments/assets/7586f8e8-851a-4fd8-9f89-c4f72285ced9" />

### How

A supplemental index file can be provided (`appstream.xml`) that is picked up similarly in nature to other supplemental files e.g. `components.xml`, `groups.xml`.

An example of an appstream.xml file is:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<PISI>
    <AppstreamCatalogs>
        <AppstreamCatalog>
            <Origin>solus-unstable-main</Origin>
            <URI>https://appstream.getsol.us/data/unstable/main/Components-x86_64.xml.gz</URI>
            <Icons size="64x64">
                <URI>https://appstream.getsol.us/data/unstable/main/icons-64x64.tar.gz</URI>
            </Icons>
            <Icons size="64x64@2">
                <URI>https://appstream.getsol.us/data/unstable/main/icons-64x64@2.tar.gz</URI>
            </Icons>
            <Icons size="128x128">
                <URI>https://appstream.getsol.us/data/unstable/main/icons-128x128.tar.gz</URI>
            </Icons>
        </AppstreamCatalog>
    </AppstreamCatalogs>
</PISI>
```

Multiple appstream catalogs can be specified.

When the repository is indexed the `</AppstreamCatalog>` tag(s) is included in the `eopkg-index.xml` file.

The origin should match the origin in the `Components-x86_64.xml.gz` file.

When an `</AppstreamCatalog>` is included in the eopkg index, eopkg will then download the appstream catalog and it's icons to `/var/lib/swcatalog/xml/` if the catalog is not installed. If the catalog is installed then eopkg will check against the Last-Modified header to see if newer tarballs exist on the remote then download and install them if necessary.

For the example `appstream.xml` file above, eopkg will install to the following paths:
`/var/lib/swcatalog/xml/solus-unstable-main.xml.gz`
`/var/lib/swcatalog/xml/solus-unstable-main.xml.gz.eopkg`
`/var/lib/swcatalog/icons/solus-unstable-main/128x128/`
`/var/lib/swcatalog/icons/solus-unstable-main/64x64/`
`/var/lib/swcatalog/icons/solus-unstable-main/64x64@2/`
 
Eopkg will place a tag on the catalog so it knows that appstream catalog is managed by itself (in this case `/var/lib/swcatalog/xml/solus-unstable-main.xml.gz.eopkg`) . If the index no longer contains an appstream catalog matching the tag, eopkg will then nuke those paths as an obsolete catalog when the index is updated.

## Test Plan

- Add `appstream.xml` to local repo
- Index local repo
- Verify `</AppstreamCatalog>` exists in the `eopkg.index.xml` file
- Update repo
- Verify that the appstream catalog & icons get installed to their correct paths
- Update appstream catalog remotely
- Update repo
- Verify that the appstream catalog updated tarballs get installed
- Remove `appstream.xml` from local repo
- Index local repo
- Verify `</AppstreamCatalog>` no longer exists in `eopkg-index.xml` file
- Update repo
- Verify that the obsolete catalog gets uninstalled

TODO: been a while since i've looked at this code but i think i wasn't particularly happy with how obsolete catalogs were managed