### PR TITLE
Handle `pisi.graph.CycleException` for a nicer error message

### DIFF
--- a/eopkg.py3
+++ b/eopkg.py3
@@ -35,6 +35,9 @@ def handle_exception(exception, value, tb):
         exit()
     elif isinstance(value, pisi.Error):
         ui.error(_("Program terminated."))
+        msg = str(value)
+        if msg:
+            ui.error(msg)
         show_traceback = ctx.get_option("debug")
     elif isinstance(value, pisi.graph.CycleException):
         ui.error(_(f"Cyclic dependency detected. The following packages cannot be installed:"))


### PR DESCRIPTION
## Summary
Adds another condition to the function `handle_exception` in `eopkg.py3` which handles `pisi.graph.CycleException.`

Closes #26.

## Test Plan
1. Create a package recipe that builds packages with a cyclic dependency.
2. Attempt to install those packages.
3. Note the unhandled exception printed to the console.
4. Check out this PR.
5. Attempt to install those packages again.
6. Note the much nicer error message informing the user that this is a packaging problem, rather than directing them to file an issue on this repository.