### PR TITLE
cli/info: Support resolving package against a specific repository

### DIFF
--- a/pisi/api.py
+++ b/pisi/api.py
@@ -785,7 +785,7 @@ def info_file(package_fn):
     return package.metadata, package.files
 
 
-def info_name(package_name, useinstalldb=False):
+def info_name(package_name, useinstalldb=False, repo=None):
     """Fetch package information for the given package."""
 
     installdb = pisi.db.installdb.InstallDB()
@@ -794,7 +794,7 @@ def info_name(package_name, useinstalldb=False):
         package = installdb.get_package(package_name)
         repo = None
     else:
-        package, repo = packagedb.get_package_repo(package_name)
+        package, repo = packagedb.get_package_repo(package_name, repo)
 
     metadata = pisi.metadata.MetaData()
     metadata.package = package

--- a/pisi/cli/info.py
+++ b/pisi/cli/info.py
@@ -27,6 +27,7 @@ Usage: info <package1> <package2> ... <packagen>
         self.installdb = pisi.db.installdb.InstallDB()
         self.componentdb = pisi.db.componentdb.ComponentDB()
         self.packagedb = pisi.db.packagedb.PackageDB()
+        self.repodb = pisi.db.repodb.RepoDB()
 
     name = ("info", None)
 
@@ -56,6 +57,13 @@ Usage: info <package1> <package2> ... <packagen>
             action="store_true",
             default=False,
             help=_("Show only paths."),
+        )
+        group.add_option(
+            "-r",
+            "--repo",
+            action="store",
+            default=None,
+            help=_("Resolve package against specified repository")
         )
         group.add_option(
             "-s",
@@ -117,8 +125,12 @@ Usage: info <package1> <package2> ... <packagen>
             self.pisifile_info(arg)
             return
 
+        if self.options.repo and not self.repodb.has_repo(self.options.repo):
+            ctx.ui.error(_("Unable to resolve repository: %s") % self.options.repo)
+            return
+
         self.installdb_info(arg)
-        self.packagedb_info(arg)
+        self.packagedb_info(arg, self.options.repo)
 
     def print_files(self, files):
         files.list.sort(key=lambda x: x.path)
@@ -175,9 +187,9 @@ Usage: info <package1> <package2> ... <packagen>
         else:
             ctx.ui.info(_("%s package is not installed") % package)
 
-    def packagedb_info(self, package):
-        if self.packagedb.has_package(package):
-            metadata, files, repo = pisi.api.info_name(package, False)
+    def packagedb_info(self, package, repo):
+        if self.packagedb.has_package(package, repo):
+            metadata, files, repo = pisi.api.info_name(package, False, repo)
             if self.options.short:
                 ctx.ui.formatted_output(_("[binary] "), noln=True, column=" ")
             else:


### PR DESCRIPTION
## Summary

Supports resolving package info against a specific repository, for example, the local repository

## Test Plan
```
$ ./eopkg.py3 info mozjs -r Unstable --debug
DEBUG: RepoDB initialized in 5.888938903808594e-05.
what the fuck Unstable
DEBUG: InstallDB initialized in 0.003209352493286133.
Installed package:
Name                : mozjs, version: 140.3.0, release: 35
Summary             : JS is Mozilla's JavaScript engine written in C/C++
Description         : JS is Mozilla's JavaScript engine written in C/C++
Licenses            : GPL-2.0-or-later, MPL-1.1
Component           : desktop.library
Dependencies        : libstdc++ zlib libgcc glibc readline libicu 
Distribution        : Solus, Dist. Release: 1
Architecture        : x86_64, Installed Size: 381.39 MB
Reverse Dependencies: libpeas-2 mozjs-devel gjs 

DEBUG: PackageDB initialized in 0.13544654846191406.
Package found in Unstable repository:
Name                : mozjs, version: 140.4.0, release: 37
Summary             : JS is Mozilla's JavaScript engine written in C/C++
Description         : JS is Mozilla's JavaScript engine written in C/C++
Licenses            : GPL-2.0-or-later, MPL-1.1
Component           : desktop.library
Dependencies        : libstdc++ libgcc readline libicu zlib glibc 
Distribution        : Solus, Dist. Release: 1
Architecture        : x86_64, Installed Size: 381.55 MB, Package Size: 347.44 MB
Reverse Dependencies: mozjs-dbginfo libpeas-2 gjs mozjs-devel 
$ ./eopkg.py3 info mozjs -r GNOME --debug
DEBUG: RepoDB initialized in 6.0558319091796875e-05.
what the fuck GNOME
DEBUG: InstallDB initialized in 0.003444671630859375.
Installed package:
Name                : mozjs, version: 140.3.0, release: 35
Summary             : JS is Mozilla's JavaScript engine written in C/C++
Description         : JS is Mozilla's JavaScript engine written in C/C++
Licenses            : GPL-2.0-or-later, MPL-1.1
Component           : desktop.library
Dependencies        : libstdc++ zlib libgcc glibc readline libicu 
Distribution        : Solus, Dist. Release: 1
Architecture        : x86_64, Installed Size: 381.39 MB
Reverse Dependencies: libpeas-2 mozjs-devel gjs 

DEBUG: PackageDB initialized in 0.1342167854309082.
Package found in GNOME repository:
Name                : mozjs, version: 140.3.0, release: 35
Summary             : JS is Mozilla's JavaScript engine written in C/C++
Description         : JS is Mozilla's JavaScript engine written in C/C++
Licenses            : GPL-2.0-or-later, MPL-1.1
Component           : desktop.library
Dependencies        : libstdc++ zlib libgcc glibc readline libicu 
Distribution        : Solus, Dist. Release: 1
Architecture        : x86_64, Installed Size: 381.39 MB, Package Size: 349.55 MB
Reverse Dependencies: libpeas-2 gjs mozjs-devel mozjs-dbginfo 

$ ./eopkg.py3 info mozjs -r what --debug
DEBUG: RepoDB initialized in 5.91278076171875e-05.
Unable to resolve repository: what
```