### PR TITLE
uneopkg: Read package before attempting to extract

### DIFF
--- a/pisi/scripts/uneopkg.py
+++ b/pisi/scripts/uneopkg.py
@@ -42,6 +42,7 @@ def main():
 
     target = "." if len(sys.argv) == 2 else sys.argv[2]
 
+    package.read()
     package.extract_pisi_files(target)
     package.extract_dir("comar", target)
     if not os.path.exists(os.path.join(target, "install")):


### PR DESCRIPTION
## Summary
Basically, `uneopkg` is a weirdly hacky little script which barely implements any of the usual pisi stuff. This PR doesn't fix that, but it does make the hack work again. 

The root cause of the bug was that `uneopkg` wasn't fully parsing the package before extracting it. This caused logic introduced in 3f93cf1d86a22a7b5ec54298417a78e1cee05489 to skip extracting files which weren't in `package.files`, because *nothing* was in `package.files`. 

Further, the nice warning also implemented in the aforementioned commit:
```
ctx.ui.warning("Ignoring unknown file in archive: %s" % repr(tarinfo.path))
```
...didn't do anything, because `uneopkg` doesn't implement anything to handle calls to `ctx.ui.*`.

Fixes #203.

## Test Plan

- Reproduce #203.
- Apply this PR.
- Try it again.
- Note that it works!