### PR TITLE
install: Don't call downloaded packages "upgrades"

### DIFF
--- a/pisi/operations/install.py
+++ b/pisi/operations/install.py
@@ -129,7 +129,7 @@ def install_pkg_names(packages, reinstall=False):
         install_op = atomicoperations.Install.from_name(package)
         paths.append(install_op.package_fname)
 
-    ctx.ui.status(_("Finished downloading package upgrades."))
+    ctx.ui.status(_("Finished downloading packages."))
 
     # Don't actually install if --fetch-only was set
     if ctx.get_option("fetch_only"):


### PR DESCRIPTION
## Summary
Fixes a minor typo in CLI output.

Fixes #202.

This PR changes a translated string, so will require All That Stuff to be dealt with.

## Test Plan
- Apply this PR.
- Install something. 
- Note the message "Finished downloading packages." which does not call downloaded packages "upgrades".