### PR TITLE
Don't lock any operations when doing a dry-run

### DIFF
--- a/pisi/api.py
+++ b/pisi/api.py
@@ -44,6 +44,10 @@ def locked(func):
     """
 
     def wrapper(*__args, **__kw):
+        # Don't lock operations if we're doing a dry run
+        if ctx.get_option("dry_run"):
+            return func(*__args, **__kw)
+
         try:
             lock = open(
                 pisi.util.join_path(pisi.context.config.lock_dir(), "pisi"), "w"


### PR DESCRIPTION
I *think* this also has the benefit of not requiring root for operations that, after all, only read the database and don't write to it.