### PR TITLE
Raise `pisi.Error` rather than `Exception` when we want the user to see it

### DIFF
--- a/pisi/atomicoperations.py
+++ b/pisi/atomicoperations.py
@@ -602,7 +602,7 @@ class Remove(AtomicOperation):
         ctx.ui.status(_("Removing package %s") % self.package_name)
         ctx.ui.notify(pisi.ui.removing, package=self.package, files=self.files)
         if not self.installdb.has_package(self.package_name):
-            raise Exception(
+            raise Error(
                 _("Trying to remove nonexistent package ") + self.package_name
             )
 

--- a/pisi/db/componentdb.py
+++ b/pisi/db/componentdb.py
@@ -3,6 +3,7 @@
 
 import re
 from pisi import translate as _
+from pisi import Error
 
 import pisi
 import pisi.db.repodb
@@ -84,7 +85,7 @@ class ComponentDB(lazydb.LazyDB):
     # Returns the component in given repo or first found component in repo order if repo is None
     def get_component(self, component_name, repo=None):
         if not self.has_component(component_name, repo):
-            raise Exception(_("Component %s not found") % component_name)
+            raise Error(_("Component %s not found") % component_name)
 
         try:
             component = pisi.component.Component()

--- a/pisi/db/installdb.py
+++ b/pisi/db/installdb.py
@@ -7,6 +7,7 @@
 import os
 import re
 from pisi import translate as _
+from pisi import Error
 
 import iksemel
 
@@ -374,4 +375,4 @@ class InstallDB(lazydb.LazyDB):
                 "%s-%s" % (package, self.installed_db[package]),
             )
 
-        raise Exception(_("Package %s is not installed") % package)
+        raise Error(_("Package %s is not installed") % package)

--- a/pisi/db/itembyrepo.py
+++ b/pisi/db/itembyrepo.py
@@ -3,6 +3,7 @@
 
 import zlib
 from pisi import translate as _
+from pisi import Error
 
 import pisi.db
 
@@ -27,7 +28,7 @@ class ItemByRepo:
             if r in self.dbobj and item in self.dbobj[r]:
                 return r
 
-        raise Exception(_("%s not found in any repository.") % str(item))
+        raise Error(_("%s not found in any repository.") % str(item))
 
     def get_item_repo(self, item, repo=None):
         for r in self.item_repos(repo):
@@ -37,7 +38,7 @@ class ItemByRepo:
                 else:
                     return self.dbobj[r][item], r
 
-        raise Exception(_("Repo item %s not found") % str(item))
+        raise Error(_("Repo item %s not found") % str(item))
 
     def get_item(self, item, repo=None):
         item, repo = self.get_item_repo(item, repo)
@@ -47,7 +48,7 @@ class ItemByRepo:
         items = []
         for r in self.item_repos(repo):
             if not self.has_repo(r):
-                raise Exception(_("Repository %s does not exist.") % repo)
+                raise Error(_("Repository %s does not exist.") % repo)
 
             if r in self.dbobj:
                 items.extend(list(self.dbobj[r].keys()))
@@ -58,7 +59,7 @@ class ItemByRepo:
         items = []
         for r in self.item_repos(repo):
             if not self.has_repo(r):
-                raise Exception(_("Repository %s does not exist.") % repo)
+                raise Error(_("Repository %s does not exist.") % repo)
 
             if r in self.dbobj:
                 items.extend(self.dbobj[r])
@@ -68,7 +69,7 @@ class ItemByRepo:
     def get_items_iter(self, repo=None):
         for r in self.item_repos(repo):
             if not self.has_repo(r):
-                raise Exception(_("Repository %s does not exist.") % repo)
+                raise Error(_("Repository %s does not exist.") % repo)
 
             for item, data in self.dbobj[r].items():
                 yield item, zlib.decompress(data) if self.compressed else data

--- a/pisi/db/packagedb.py
+++ b/pisi/db/packagedb.py
@@ -18,6 +18,7 @@ import pisi.dependency
 import pisi.db.itembyrepo
 import pisi.db.lazydb as lazydb
 from pisi import translate as _
+from pisi import Error
 
 
 class PackageDB(lazydb.LazyDB):
@@ -125,7 +126,7 @@ class PackageDB(lazydb.LazyDB):
                         doc, pkgConfigs, pkgConfigs32)
         else:
             if repo not in repodb.list_repos(only_active=False):
-                raise Exception(_("Repo %s not found.") % repo)
+                raise Error(_("Repo %s not found.") % repo)
             doc = repodb.get_repo_doc(repo)
             pkgConfig, pkgConfigs32 = map_providers(
                         doc, pkgConfigs, pkgConfigs32)
@@ -214,13 +215,13 @@ class PackageDB(lazydb.LazyDB):
 
     def get_version_and_distro_release(self, name, repo):
         if not self.has_package(name, repo):
-            raise Exception(_("Package %s not found.") % name)
+            raise Error(_("Package %s not found.") % name)
         pkg_doc = iksemel.parseString(self.pdb.get_item(name, repo).decode())
         return self.__get_version(pkg_doc) + self.__get_distro_release(pkg_doc)
 
     def get_version(self, name, repo):
         if not self.has_package(name, repo):
-            raise Exception(_("Package %s not found.") % name)
+            raise Error(_("Package %s not found.") % name)
 
         pkg_doc = iksemel.parseString(self.pdb.get_item(name, repo).decode())
         return self.__get_version(pkg_doc)

--- a/pisi/history.py
+++ b/pisi/history.py
@@ -6,6 +6,7 @@ import time
 from functools import cmp_to_key
 
 from pisi import context as ctx
+from pisi import Error
 from pisi import translate as _
 from pisi.pxml import autoxml, xmlfile
 
@@ -105,7 +106,7 @@ class History(xmlfile.XmlFile, metaclass=autoxml.autoxml):
             "takeback",
             "repoupdate",
         ]:
-            raise Exception(_("Unknown package operation"))
+            raise Error(_("Unknown package operation"))
 
         opno = self._get_latest()
         self.histfile = "%s_%s.xml" % (opno, operation)
@@ -133,7 +134,7 @@ class History(xmlfile.XmlFile, metaclass=autoxml.autoxml):
             "downgrade",
             "snapshot",
         ]:
-            raise Exception(_("Unknown package operation"))
+            raise Error(_("Unknown package operation"))
 
         package = Package()
         package.operation = operation

--- a/pisi/operations/helper.py
+++ b/pisi/operations/helper.py
@@ -5,6 +5,7 @@ import os
 
 from ordered_set import OrderedSet as set
 from pisi import translate as _
+from pisi import Error
 
 import pisi
 import pisi.context as ctx
@@ -55,7 +56,7 @@ def check_conflicts(order, packagedb):
     (C, D, pkg_conflicts) = pisi.conflict.calculate_conflicts(order, packagedb)
 
     if D:
-        raise Exception(
+        raise Error(
             _("Selected packages [%s] are in conflict with each other.")
             % util.strlist(list(D))
         )
@@ -71,7 +72,7 @@ def check_conflicts(order, packagedb):
         ctx.ui.info(_("The following packages have conflicts:\n%s") % conflicts)
 
         if not ctx.ui.confirm(_("Remove the following conflicting packages?")):
-            raise Exception(_("Conflicting packages should be removed to continue"))
+            raise Error(_("Conflicting packages should be removed to continue"))
 
     return list(C)
 

--- a/pisi/operations/install.py
+++ b/pisi/operations/install.py
@@ -8,6 +8,7 @@ import zipfile
 
 from ordered_set import OrderedSet as set
 from pisi import translate as _
+from pisi import Error
 
 import pisi
 import pisi.context as ctx
@@ -174,7 +175,7 @@ def install_pkg_files(package_URIs, reinstall=False):
 
     for x in package_URIs:
         if not x.endswith(ctx.const.package_suffix):
-            raise Exception(_("Mixing file names and package names not supported yet."))
+            raise Error(_("Mixing file names and package names not supported yet."))
 
     # filter packages that are already installed
     tobe_installed, already_installed = [], set()
@@ -229,7 +230,7 @@ def install_pkg_files(package_URIs, reinstall=False):
                 pkg.distributionRelease
                 != ctx.config.values.general.distribution_release
             ):
-                raise Exception(
+                raise Error(
                     _(
                         "Package %s is not compatible with your distribution release %s %s."
                     )
@@ -240,7 +241,7 @@ def install_pkg_files(package_URIs, reinstall=False):
                     )
                 )
             if pkg.architecture != ctx.config.values.general.architecture:
-                raise Exception(
+                raise Error(
                     _("Package %s (%s) is not compatible with your %s architecture.")
                     % (x, pkg.architecture, ctx.config.values.general.architecture)
                 )
@@ -267,7 +268,7 @@ def install_pkg_files(package_URIs, reinstall=False):
     # be satisfied by installing packages from the repo
     for dep in dep_unsatis:
         if not dep.satisfied_by_repo():
-            raise Exception(_("External dependencies not satisfied: %s") % dep)
+            raise Error(_("External dependencies not satisfied: %s") % dep)
 
     # if so, then invoke install_pkg_names
     extra_packages = [x.package for x in dep_unsatis]
@@ -280,7 +281,7 @@ def install_pkg_files(package_URIs, reinstall=False):
         )
         ctx.ui.info(util.format_by_columns(sorted(extra_packages)))
         if not ctx.ui.confirm(_("Do you want to continue?")):
-            raise Exception(_("External dependencies not satisfied"))
+            raise Error(_("External dependencies not satisfied"))
         install_pkg_names(extra_packages, reinstall=True)
 
     class PackageDB:
@@ -375,7 +376,7 @@ def plan_install_pkg_names(A):
                 # we don't deal with already *satisfied* dependencies
                 if not dep.satisfied_by_installed():
                     if not dep.satisfied_by_repo():
-                        raise Exception(
+                        raise Error(
                             _("%s dependency of package %s is not satisfied")
                             % (dep, pkg.name)
                         )

--- a/pisi/operations/remove.py
+++ b/pisi/operations/remove.py
@@ -5,6 +5,7 @@ import signal
 import sys
 
 from pisi import translate as _
+from pisi import Error
 
 import pisi
 import pisi.context as ctx
@@ -298,7 +299,7 @@ def list_orphans():
 
 def remove_conflicting_packages(conflicts):
     if remove(conflicts, ignore_dep=True, ignore_safety=True):
-        raise Exception(_("Conflicts remain"))
+        raise Error(_("Conflicts remain"))
 
 
 def remove_obsoleted_packages():
@@ -307,9 +308,9 @@ def remove_obsoleted_packages():
     obsoletes = list(filter(installdb.has_package, packagedb.get_obsoletes()))
     if obsoletes:
         if remove(obsoletes, ignore_dep=True, ignore_safety=True):
-            raise Exception(_("Obsoleted packages remaining"))
+            raise Error(_("Obsoleted packages remaining"))
 
 
 def remove_replaced_packages(replaced):
     if remove(replaced, ignore_dep=True, ignore_safety=True):
-        raise Exception(_("Replaced package remains"))
+        raise Error(_("Replaced package remains"))

--- a/pisi/operations/upgrade.py
+++ b/pisi/operations/upgrade.py
@@ -6,6 +6,7 @@ import sys
 
 from ordered_set import OrderedSet as set
 from pisi import translate as _
+from pisi import Error
 
 import pisi
 import pisi.ui as ui
@@ -306,7 +307,7 @@ def plan_upgrade(A, force_replaced=True, replaces=None):
                 ctx.ui.error(
                     _("Dependency %s of %s cannot be satisfied") % (dep, pkg.name)
                 )
-                raise Exception(_("Upgrade is not possible."))
+                raise Error(_("Upgrade is not possible."))
 
     def add_resolvable_conflicts(pkg, Bp):
         """Try to resolve conflicts by upgrading


### PR DESCRIPTION
## Summary
Changes introduced in #197 inadvertently meant that quite a few very common errors no longer got printed. It turns out that we were raising a bare `Exception` in many places when intending to tell the user about an error, which is poor practice in general... and just plain silly when we already have an exception class (`pisi.Error`) for that purpose. 

It's very possible that we should have more specific exception classes in the future, but using `pisi.Error` as a catchall for user-facing errors makes sense to me for now. 

Fixes #207.

## Test Plan
- Try installing a package that doesn't exist. See that you just get "Program terminated".
- Apply this PR.
- Try installing a package that doesn't exist. See that you get a proper error.
- Assume that 1: since the rest of the logic leading to raising an exception didn't change, and 2: that all the other changed exceptions were not being printed for the same reason as the one you just tested, that the issue is fixed everywhere that the PR touches.