### PR TITLE
history: Optimize expensive files sort lambda call in _get_latest()

### DIFF
--- a/pisi/history.py
+++ b/pisi/history.py
@@ -165,8 +165,10 @@ class History(xmlfile.XmlFile, metaclass=autoxml.autoxml):
         if not files:
             return "001"
 
-        files.sort(
-            key=cmp_to_key(lambda x, y: int(x.split("_")[0]) - int(y.split("_")[0]))
-        )
+        def extract_prefix(s):
+            i = s.find("_")
+            return int(s[:i]) if i != -1 else int(s)
+
+        files.sort(key=extract_prefix)
         no, opxml = files[-1].split("_")
         return "%03d" % (int(no) + 1)


### PR DESCRIPTION
## Summary

Previously, when installing a package, `history.py:169(<lambda>)` and `{method 'split' of 'str' objects}` would be very close to the top of a cProfile.

```
ncalls  tottime  percall  cumtime  percall filename:lineno(function)
1       0.823    0.823    0.823    0.823 {built-in method posix.system}
1161    0.519    0.000    0.519    0.000 {method 'decompress' of '_lzma.LZMADecompressor' objects}
3       0.130    0.043    0.136    0.045 {built-in method _pickle.load}
2597    0.079    0.000    0.079    0.000 {built-in method iksemel.parse}
2846    0.065    0.000    0.065    0.000 {built-in method iksemel.parseString}
92814   0.062    0.000    0.092    0.000 history.py:169(<lambda>)
42      0.048    0.001    0.048    0.001 {built-in method builtins.compile}
31684   0.047    0.000    0.090    0.000 repodb.py:85(get_status)
216103  0.036    0.000    0.036    0.000 {method 'split' of 'str' objects}
```

Now, with this change this call disappears from the profile

## Performance
```
sudo hyperfine "/usr/bin/eopkg.py3 it cemu-2.6-19-1-x86_64.eopkg --ignore-revdeps-of-deps" "/home/ninya/eopkg/eopkg.py3 it cemu-2.6-19-1-x86_64.eopkg --ignore-revdeps-of-deps"
Benchmark 1: /usr/bin/eopkg.py3 it cemu-2.6-19-1-x86_64.eopkg --ignore-revdeps-of-deps
  Time (mean ± σ):      2.155 s ±  0.041 s    [User: 1.748 s, System: 0.374 s]
  Range (min … max):    2.116 s …  2.225 s    10 runs
 
Benchmark 2: /home/ninya/eopkg/eopkg.py3 it cemu-2.6-19-1-x86_64.eopkg --ignore-revdeps-of-deps
  Time (mean ± σ):      2.102 s ±  0.030 s    [User: 1.715 s, System: 0.355 s]
  Range (min … max):    2.067 s …  2.152 s    10 runs
 
Summary
  /home/ninya/eopkg/eopkg.py3 it cemu-2.6-19-1-x86_64.eopkg --ignore-revdeps-of-deps ran
    1.03 ± 0.02 times faster than /usr/bin/eopkg.py3 it cemu-2.6-19-1-x86_64.eopkg --ignore-revdeps-of-deps
```

## Test Plan

Perform a few eopkg operations and confirm that history.xml file was still valid