### PR TITLE
db/repodb: Cache repos in memory at init instead of re-reading the xml

### DIFF
--- a/pisi/db/repodb.py
+++ b/pisi/db/repodb.py
@@ -36,6 +36,7 @@ class RepoOrder:
     def __init__(self):
         self._doc = None
         self.legacy_repo_used = None
+        self._repos_cache = {}
         self.repos = self._get_repos()
 
     def add(self, repo_name, repo_url, repo_type="remote"):
@@ -70,6 +71,7 @@ class RepoOrder:
     def set_status(self, repo_name, status):
         repo_doc = self._get_doc()
 
+        found = False
         for r in repo_doc.tags("Repo"):
             if r.getTagData("Name") == repo_name:
                 status_node = r.getTag("Status")
@@ -79,37 +81,16 @@ class RepoOrder:
                 else:
                     status_node = r.insertTag("Status")
                     status_node.insertData(status)
+                found = True
 
-        self._update(repo_doc)
+        if found:
+            self._update(repo_doc)
 
     def get_status(self, repo_name):
-        repo_doc = self._get_doc()
-        for r in repo_doc.tags("Repo"):
-            if r.getTagData("Name") == repo_name:
-                status_node = r.getTag("Status")
-                if status_node:
-                    status = status_node.firstChild().data()
-                    if status in ["active", "inactive"]:
-                        return status
-        return "inactive"
+        return self._repos_cache.get(repo_name, {}).get("status", "inactive")
 
     def get_uri(self, repo_name):
-        repo_doc = self._get_doc()
-        url = ""
-
-        for r in repo_doc.tags("Repo"):
-            name = r.getTagData("Name")
-            uri = r.getTagData("Url")
-
-            if name == repo_name:
-                url = pisi.urlcheck.switch_from_legacy(uri)
-
-                if url != uri:
-                    self.legacy_repo_used = True
-
-                break
-
-        return url.rstrip()
+        return self._repos_cache.get(repo_name, {}).get("url", "")
 
     def remove(self, repo_name):
         repo_doc = self._get_doc()
@@ -151,14 +132,24 @@ class RepoOrder:
     def _get_repos(self):
         repo_doc = self._get_doc()
         order = {}
+        self._repos_cache = {}
 
         for r in repo_doc.tags("Repo"):
             media = r.getTagData("Media")
             name = r.getTagData("Name")
             status = r.getTagData("Status")
             old_url = r.getTagData("Url")
+
             url = pisi.urlcheck.switch_from_legacy(old_url)
+            if url != old_url:
+                self.legacy_repo_used = True
+
             order.setdefault(media, []).append(name)
+            self._repos_cache[name] = {
+                "media": media,
+                "status": status if status in ["active", "inactive"] else "inactive",
+                "url": url.rstrip(),
+            }
 
         return order
 


### PR DESCRIPTION
## Summary

For some reason, when installing a package repodb.get_status() ends up being called almost 32 thousand times...

This makes is so this call ends up pretty close to the top in a cProfile when installing a package.

Let's just cache it in memory as the repodb won't be changed whilst an operation is ongoing.

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.775    0.775    0.775    0.775 {built-in method posix.system}
     1161    0.517    0.000    0.517    0.000 {method 'decompress' of '_lzma.LZMADecompressor' objects}
        3    0.130    0.043    0.136    0.045 {built-in method _pickle.load}
     2597    0.079    0.000    0.079    0.000 {built-in method iksemel.parse}
     2846    0.067    0.000    0.067    0.000 {built-in method iksemel.parseString}
    31684    0.047    0.000    0.092    0.000 repodb.py:85(get_status)
```

With this change, this call disappears from the cProfile

## Performance

Before:
```
sudo hyperfine "/home/ninya/eopkg/eopkg.py3 it cemu-2.6-19-1-x86_64.eopkg --ignore-revdeps-of-deps"
Benchmark 1: /home/ninya/eopkg/eopkg.py3 it cemu-2.6-19-1-x86_64.eopkg --ignore-revdeps-of-deps
  Time (mean ± σ):      2.102 s ±  0.028 s    [User: 1.703 s, System: 0.365 s]
  Range (min … max):    2.069 s …  2.153 s    10 runs
```

Now:
```
sudo hyperfine "/home/ninya/eopkg/eopkg.py3 it cemu-2.6-19-1-x86_64.eopkg --ignore-revdeps-of-deps"
Benchmark 1: /home/ninya/eopkg/eopkg.py3 it cemu-2.6-19-1-x86_64.eopkg --ignore-revdeps-of-deps
  Time (mean ± σ):      2.073 s ±  0.025 s    [User: 1.690 s, System: 0.350 s]
  Range (min … max):    2.040 s …  2.119 s    10 runs
```

## Test Plan

Run a few eopkg operations, add/remove and list repos.