### PR TITLE
db/itembyrepo: Store repodb during init instead of reinitializing it

### DIFF
--- a/pisi/db/itembyrepo.py
+++ b/pisi/db/itembyrepo.py
@@ -12,6 +12,7 @@ class ItemByRepo:
     def __init__(self, dbobj, compressed=False):
         self.dbobj = dbobj
         self.compressed = compressed
+        self.repodb = pisi.db.repodb.RepoDB()
 
     def has_repo(self, repo):
         return repo in self.dbobj
@@ -24,7 +25,7 @@ class ItemByRepo:
         return False
 
     def which_repo(self, item):
-        for r in pisi.db.repodb.RepoDB().list_repos():
+        for r in self.repodb.list_repos():
             if r in self.dbobj and item in self.dbobj[r]:
                 return r
 


### PR DESCRIPTION
## Summary

When installing a package, various itembyrepo and by extension, repodb calls, take a lot of total cumulative time.

Let's store the repodb as part of itembyrepo instead of reinitializing it for various calls.

Note that we can't use the stored value in item_repos() as the repodb may not be reinitialized when that is called.

This gives approx. a ~1.08x speedup when installing a 19MiB .eopkg.

## Test Plan

Install a few packages, use eopkg as normal