### PR TITLE
pxml/xmlext: Optimize getNode() by using iksemel API

### DIFF
--- a/pisi/pxml/xmlext.py
+++ b/pisi/pxml/xmlext.py
@@ -88,22 +88,21 @@ def getNode(node, tagpath):
     if tagpath == "":
         return node
 
-    assert type(tagpath) == str
+    assert type(tagpath) is str
     tags = tagpath.split("/")
     assert len(tags) > 0
 
     # iterative code to search for the path
     for tag in tags:
-        currentNode = None
-        for child in node.tags():
-            if child.name() == tag:
-                currentNode = child
-                break
-        if not currentNode:
+        found = False
+        for child in node.tags(tag):
+            node = child
+            found = True
+            break
+        if not found:
             return None
-        else:
-            node = currentNode
-    return currentNode
+
+    return node
 
 
 def createTagPath(node, tags):


### PR DESCRIPTION
## Summary

Instead of doing a comparison of child.name() == tag against every child tag, use iksemel's node.tags(tag) to return only the tags matching the specified name.

As iksemel is written in C this ends up a lot faster.

Profile from installing a 19MiB .eopkg:

ncalls  tottime  percall  cumtime  percall filename:lineno(function)

Before:
`13708    0.020    0.000    0.035    0.000 xmlext.py:85(getNode)`

Now:
`13708    0.010    0.000    0.018    0.000 xmlext.py:85(getNode)`

## Test Plan

Install a few packages, use a few normal eopkg operations, did a quick sanity check that the node result(s) were the same before and after