### PR TITLE
fetcher: Reimplement using python-requests

### DIFF
--- a/pisi/api.py
+++ b/pisi/api.py
@@ -429,6 +429,8 @@ def fetch(packages=[], path=os.path.curdir):
     repodb = pisi.db.repodb.RepoDB()
     fetcher = Fetcher()
 
+    fetch_items = []
+
     for name in packages:
         package, repo = packagedb.get_package_repo(name)
         ctx.ui.info(_("%s package found in %s repository") % (package.name, repo))
@@ -446,8 +448,12 @@ def fetch(packages=[], path=os.path.curdir):
                 os.path.dirname(repodb.get_repo_url(repo)), str(uri.path())
             )
 
-        # TODO(Evan): Error handling
-        fetcher.fetch(url, path)
+        fetch_items.append((url, path))
+
+    # TODO(Evan): Error handling
+    if fetch_items:
+        fetcher.fetch_multi(fetch_items)
+
 
 
 @locked

--- a/pisi/api.py
+++ b/pisi/api.py
@@ -5,7 +5,6 @@ import fcntl
 import os
 import signal
 import re
-from . import fetcher
 
 from pisi import translate as _
 
@@ -36,6 +35,7 @@ import pisi.operations.check
 import pisi.operations.build
 import pisi.signalhandler as signalhandler
 import pisi.errors
+from pisi.fetcher import Fetcher
 
 
 def locked(func):
@@ -427,6 +427,8 @@ def fetch(packages=[], path=os.path.curdir):
     """
     packagedb = pisi.db.packagedb.PackageDB()
     repodb = pisi.db.repodb.RepoDB()
+    fetcher = Fetcher()
+
     for name in packages:
         package, repo = packagedb.get_package_repo(name)
         ctx.ui.info(_("%s package found in %s repository") % (package.name, repo))
@@ -444,7 +446,8 @@ def fetch(packages=[], path=os.path.curdir):
                 os.path.dirname(repodb.get_repo_url(repo)), str(uri.path())
             )
 
-        fetcher.fetch_url(url, path, ctx.ui.Progress)
+        # TODO(Evan): Error handling
+        fetcher.fetch(url, path)
 
 
 @locked
@@ -467,7 +470,9 @@ def remove(packages, ignore_dependency=False, ignore_safety=False):
     @param ignore_safety: system.base packages can also be removed if True
     """
     pisi.db.historydb.HistoryDB().create_history("remove")
-    return pisi.operations.remove.remove(packages, ignore_dependency, ignore_safety, force_prompt=True)
+    return pisi.operations.remove.remove(
+        packages, ignore_dependency, ignore_safety, force_prompt=True
+    )
 
 
 @locked
@@ -939,6 +944,7 @@ def rebuild_db(files=False):
 
     filesdb = pisi.db.filesdb.FilesDB()
     filesdb.init(force_rebuild=True)
+
 
 ############# FIXME: this was a quick fix. ##############################
 

--- a/pisi/api.py
+++ b/pisi/api.py
@@ -426,34 +426,25 @@ def fetch(packages=[], path=os.path.curdir):
     to the current working directory.
     """
     packagedb = pisi.db.packagedb.PackageDB()
-    repodb = pisi.db.repodb.RepoDB()
     fetcher = Fetcher()
 
     fetch_items = []
 
     for name in packages:
-        package, repo = packagedb.get_package_repo(name)
-        ctx.ui.info(_("%s package found in %s repository") % (package.name, repo))
-        uri = pisi.uri.URI(package.packageURI)
-        output = os.path.join(path, uri.path())
-        if os.path.exists(output) and package.packageHash == pisi.util.sha1_file(
+        resource = packagedb.get_resource(name)
+        ctx.ui.info(_("Package %s found in repository") % name)
+
+        output = os.path.join(path, resource.uri.filename())
+        if os.path.exists(output) and resource.expected_hash == pisi.util.sha1_file(
             output
         ):
-            ctx.ui.warning(_("%s package already fetched") % uri.path())
+            ctx.ui.warning(_("%s package already fetched") % resource.uri.filename())
             continue
-        if uri.is_absolute_path():
-            url = str(uri)
-        else:
-            url = os.path.join(
-                os.path.dirname(repodb.get_repo_url(repo)), str(uri.path())
-            )
 
-        fetch_items.append((url, path))
+        fetch_items.append((resource.uri, path, resource.uri.filename()))
 
-    # TODO(Evan): Error handling
     if fetch_items:
         fetcher.fetch_multi(fetch_items)
-
 
 
 @locked

--- a/pisi/atomicoperations.py
+++ b/pisi/atomicoperations.py
@@ -69,71 +69,32 @@ class Install(AtomicOperation):
     @staticmethod
     def from_name(name, ignore_dep=None):
         packagedb = pisi.db.packagedb.PackageDB()
-        # download package and return an installer object
-        # find package in repository
-        repo = packagedb.which_repo(name)
-        if repo:
-            repodb = pisi.db.repodb.RepoDB()
-            ctx.ui.info(_("Package %s found in repository %s") % (name, repo))
+        resource = packagedb.get_resource(name)
 
-            repo = repodb.get_repo(repo)
-            pkg = packagedb.get_package(name)
-            delta = None
+        ctx.ui.info(_("Package %s found in repository") % name)
+        ctx.ui.info(_("Package URI: %s") % resource.uri, verbose=True)
 
-            installdb = pisi.db.installdb.InstallDB()
-            # Package is installed. This is an upgrade. Check delta.
-            if installdb.has_package(pkg.name):
-                (
-                    version,
-                    release,
-                    build,
-                    distro,
-                    distro_release,
-                ) = installdb.get_version_and_distro_release(pkg.name)
-                if distro_release == pkg.distributionRelease:
-                    delta = pkg.get_delta(release)
+        if resource.uri.is_remote_file():
+            if os.path.exists(resource.local_path):
+                if util.sha1_file(resource.local_path) != resource.expected_hash:
+                    os.unlink(resource.local_path)
 
-            ignore_delta = ctx.config.values.general.ignore_delta
+            if not os.path.exists(resource.local_path):
+                # Explicitly download if not cached.
+                # Note: In the future, this should be handled by a separate fetch stage.
+                dest = os.path.dirname(resource.local_path)
+                pisi.file.File.download(resource.uri, dest)
 
-            # If delta exists than use the delta uri.
-            if delta and not ignore_delta:
-                pkg_uri = delta.packageURI
-                pkg_hash = delta.packageHash
-            else:
-                pkg_uri = pkg.packageURI
-                pkg_hash = pkg.packageHash
-
-            uri = pisi.uri.URI(pkg_uri)
-            if uri.is_absolute_path():
-                pkg_path = str(pkg_uri)
-            else:
-                pkg_path = os.path.join(
-                    os.path.dirname(repo.indexuri.get_uri()), str(uri.path())
-                )
-
-            ctx.ui.info(_("Package URI: %s") % pkg_path, verbose=True)
-
-            # Bug 4113
-            cached_file = pisi.package.Package.is_cached(pkg_path)
-            if cached_file and util.sha1_file(cached_file) != pkg_hash:
-                os.unlink(cached_file)
-                cached_file = None
-
-            install_op = Install(pkg_path, ignore_dep)
-
-            # Bug 4113
-            if not cached_file:
-                downloaded_file = install_op.package.filepath
-                if pisi.util.sha1_file(downloaded_file) != pkg_hash:
-                    raise pisi.Error(
-                        _(
-                            "Download Error: Package does not match the repository package."
-                        )
-                    )
-
-            return install_op
+            pkg_path = resource.local_path
         else:
-            raise Error(_("Package %s not found in any active repository.") % name)
+            pkg_path = resource.uri.path()
+
+        if util.sha1_file(pkg_path) != resource.expected_hash:
+            raise Error(
+                _("Download Error: Package does not match the repository package.")
+            )
+
+        return Install(pkg_path, ignore_dep)
 
     def __init__(self, package_fname, ignore_dep=None, ignore_file_conflicts=None):
         "initialize from a file name"

--- a/pisi/db/packagedb.py
+++ b/pisi/db/packagedb.py
@@ -4,21 +4,25 @@
 # installation database
 #
 
+import datetime
+import gettext
+import gzip
+import os
 import re
 import time
-import gzip
-import gettext
-import datetime
 
 import iksemel
 
+import pisi.context
 import pisi.db
-import pisi.metadata
-import pisi.dependency
 import pisi.db.itembyrepo
 import pisi.db.lazydb as lazydb
-from pisi import translate as _
+import pisi.dependency
+import pisi.metadata
+import pisi.package
+import pisi.uri
 from pisi import Error
+from pisi import translate as _
 
 
 class PackageDB(lazydb.LazyDB):
@@ -231,6 +235,57 @@ class PackageDB(lazydb.LazyDB):
         package = pisi.metadata.Package()
         package.parse(pkg)
         return package, repo
+
+    def get_resource(self, name):
+        repodb = pisi.db.repodb.RepoDB()
+        installdb = pisi.db.installdb.InstallDB()
+
+        repo_name = self.which_repo(name)
+        if not repo_name:
+            raise Error(_("Package %s not found in any active repository.") % name)
+
+        repo = repodb.get_repo(repo_name)
+        pkg = self.get_package(name)
+        delta = None
+
+        if installdb.has_package(pkg.name):
+            (
+                version,
+                release,
+                build,
+                distro,
+                distro_release,
+            ) = installdb.get_version_and_distro_release(pkg.name)
+            if distro_release == pkg.distributionRelease:
+                delta = pkg.get_delta(release)
+
+        ignore_delta = pisi.context.config.values.general.ignore_delta
+
+        if delta and not ignore_delta:
+            pkg_uri_str = delta.packageURI
+            pkg_hash = delta.packageHash
+            pkg_size = delta.packageSize
+            is_delta = True
+        else:
+            pkg_uri_str = pkg.packageURI
+            pkg_hash = pkg.packageHash
+            pkg_size = pkg.packageSize
+            is_delta = False
+
+        uri = pisi.uri.URI(pkg_uri_str)
+        if not uri.is_absolute_path():
+            pkg_uri_str = os.path.join(
+                os.path.dirname(repo.indexuri.get_uri()), str(uri.path())
+            )
+
+        uri = pisi.uri.URI(pkg_uri_str)
+        local_path = os.path.join(
+            pisi.context.config.cached_packages_dir(), uri.filename()
+        )
+
+        return pisi.package.PackageResource(
+            name, uri, pkg_hash, pkg_size, local_path, is_delta
+        )
 
     def which_repo(self, name):
         return self.pdb.which_repo(name)

--- a/pisi/fetcher.py
+++ b/pisi/fetcher.py
@@ -8,12 +8,10 @@ from concurrent.futures import ThreadPoolExecutor
 import requests
 from requests import HTTPError
 from requests.adapters import HTTPAdapter
-
 from tqdm import tqdm
 
 import pisi
 import pisi.context as ctx
-
 from pisi import translate as _
 from pisi.uri import URI
 
@@ -68,7 +66,7 @@ class Fetcher:
             with (
                 open(destination, "wb") as f,
                 tqdm(
-                    desc=destination,
+                    desc=os.path.basename(destination),
                     total=total,
                     unit="iB",
                     unit_scale=True,

--- a/pisi/fetcher.py
+++ b/pisi/fetcher.py
@@ -3,6 +3,7 @@
 
 import os
 import time
+from concurrent.futures import ThreadPoolExecutor
 
 import requests
 from requests import HTTPError
@@ -48,12 +49,15 @@ class Fetcher:
         proxies = self._get_proxies()
         self.session.proxies.update(proxies)
 
-    def download_file(self, url: str, destination: str) -> None:
+    def download_file(
+        self, url: str, destination: str, progress_bar_pos: int = 0
+    ) -> None:
         """
         Download a remote resource to a local file.
 
         :param str url: The URL of the resource to download.
         :param str destination: The destination file to download to.
+        :param int progress_bar_pos: The position of the progress bar.
         """
         with self.session.get(url.get_uri(), stream=True, timeout=15) as resp:
             resp.raise_for_status()
@@ -69,6 +73,7 @@ class Fetcher:
                     unit="iB",
                     unit_scale=True,
                     unit_divisor=1024,
+                    position=progress_bar_pos,
                 ) as bar,
             ):
                 for chunk in resp.iter_content(chunk_size=MAX_CHUNK_SIZE):
@@ -90,7 +95,12 @@ class Fetcher:
                         if elapsed < expected_time:
                             time.sleep(expected_time - elapsed)
 
-    def fetch(self, url: URI | str, dest_dir: str, filename: str = None) -> None:
+    def fetch(
+        self, url: URI | str,
+        dest_dir: str,
+        filename: str = None,
+        progress_bar_pos: int = 0
+    ) -> None:
         """
         Fetches a remote resource.
 
@@ -99,6 +109,7 @@ class Fetcher:
         :param str dest_dir: The directory to save the downloaded file to.
         :param filename: The name of the file to use.
         :type filename: str | None
+        :param int progress_bar_pos: The position of the progress bar.
         """
         # This is silly and I hate it.
         if type(url) is str:
@@ -116,9 +127,42 @@ class Fetcher:
             raise IOError(_(f"Unable to access destination file '{archive_file}'"))
 
         try:
-            self.download_file(url, archive_file)
+            self.download_file(url, archive_file, progress_bar_pos)
         except HTTPError:
             raise
+
+    def fetch_multi(self, items: list) -> None:
+        """
+        Fetches multiple remote resources concurrently.
+
+        :param items: A list of (url, dest_dir, filename) tuples.
+        """
+
+        # TODO(Joey): Add a seperate config value for this
+        max_workers = pisi.util.parse_jobs(ctx.config.values.build.jobs)
+        # Cap the number of concurrent downloads to 8 to avoid overloading
+        if max_workers > 8:
+            max_workers = 8
+
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = []
+
+            for i, item in enumerate(items):
+                url, dest_dir, *rest = item
+                filename = rest[0] if rest else None
+
+                futures.append(
+                    executor.submit(
+                        self.fetch, url, dest_dir, filename, i % max_workers
+                    )
+                )
+
+            for future in futures:
+                try:
+                    future.result()
+                except Exception as e:
+                    ctx.ui.error(str(e))
+                    raise
 
     def _get_bandwidth_limit(self) -> int:
         bandwidth_limit = (

--- a/pisi/fetcher.py
+++ b/pisi/fetcher.py
@@ -1,311 +1,160 @@
-# SPDX-FileCopyrightText: 2005-2011 TUBITAK/UEKAE, 2013-2017 Ikey Doherty, Solus Project
+# SPDX-FileCopyrightText: 2026 Solus Project
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-"""Yet another Pisi module for fetching files from various sources. Of
-course, this is not limited to just fetching source files. We fetch
-all kinds of things: source tarballs, index files, packages, and God
-knows what."""
-
-# python standard library modules
-import base64
-import contextlib
 import os
-import shutil
 import time
-import urllib.request, urllib.error, urllib.parse
-from urllib.error import URLError
+
+import requests
+from requests import HTTPError
+from requests.adapters import HTTPAdapter
+
+from tqdm import tqdm
+
+import pisi
+import pisi.context as ctx
 
 from pisi import translate as _
+from pisi.uri import URI
 
-# pisi modules
-import pisi
-import pisi.util as util
-import pisi.context as ctx
-import pisi.uri
-
-
-class FetchError(pisi.Error):
-    pass
-
-
-class FetchHandler:
-    def __init__(self, url, archive, bandwidth_limit, start_time):
-        self.url = url
-        self.percent = None
-        self.rate = 0.0
-        self.size = 0
-        self.eta = "--:--:--"
-        self.symbol = "--/-"
-        self.last_updated = 0
-        self.filename = url.filename()
-        self.total_size = 0.0
-        self.exist_size = 0
-        self.bandwidth_limit = bandwidth_limit
-        if os.path.exists(archive):
-            self.exist_size = os.path.getsize(archive)
-
-        self.now = lambda: time.time()
-        self.t_diff = lambda: self.now() - self.s_time
-        self.e_diff = lambda: self.now() - start_time
-
-        self.s_time = self.now()
-
-    def update(self, blocknum, bs, size):
-        self.total_size = size + self.exist_size
-        self.size = blocknum * bs + self.exist_size
-        if self.total_size:
-            self.percent = self.size * 100.0 / self.total_size
-            if self.percent > 100:
-                self.percent = 100
-        else:
-            self.percent = 0
-
-        if int(self.now()) != int(self.last_updated) and self.size > 0:
-            try:
-                self.rate, self.symbol = util.human_readable_rate(
-                    (self.size - self.exist_size) / (self.now() - self.s_time)
-                )
-            except ZeroDivisionError:
-                return
-            if self.total_size:
-                self.eta = "%02d:%02d:%02d" % tuple(
-                    [
-                        i
-                        for i in time.gmtime(
-                            (self.e_diff() * (100 - self.percent)) / self.percent
-                        )[3:6]
-                    ]
-                )
-
-        self._update_ui()
-        self._limit_bandwidth()
-
-    def _limit_bandwidth(self):
-        if self.bandwidth_limit:
-            expected_time = (self.size - self.exist_size) / self.bandwidth_limit
-            sleep_time = expected_time - self.t_diff()
-            if sleep_time > 0:
-                time.sleep(sleep_time)
-
-    def _update_ui(self):
-        ctx.ui.display_progress(
-            operation="fetching",
-            percent=self.percent,
-            filename=self.filename,
-            total_size=self.total_size or self.size,
-            downloaded_size=self.size,
-            rate=self.rate,
-            eta=self.eta,
-            symbol=self.symbol,
-        )
-
-        self.last_updated = self.now()
+"""Maximum size in bytes of a download chunk to process at a time."""
+MAX_CHUNK_SIZE = 8192
 
 
 class Fetcher:
-    """Fetcher can fetch a file from various sources using various
-    protocols."""
+    """Handles an HTTP session for making one or more download requests.
 
-    def __init__(self, url, destdir="/tmp", destfile=None):
-        if not isinstance(url, pisi.uri.URI):
-            url = pisi.uri.URI(url)
+    It supports automatic retries (http/https only), bandwidth limits,
+    and network proxies. Values for these settings are read from the
+    global config via the Pisi context. This may change in the future.
 
-        self.url = url
-        self.destdir = destdir
-        self.destfile = destfile
-        self.progress = None
+    Attributes:
+        bandwidth_limit (int): The speed in bits per second that shall
+            not be exceeded during downloads. Set to 0 for no limit.
+        max_retries (int): The maximum number of times that a download
+            can be retried before giving up. Default 5
+        session (requests.Session): The HTTP session.
+    """
 
-        self.archive_file = os.path.join(destdir, destfile or url.filename())
-        self.partial_file = (
-            os.path.join(self.destdir, self.url.filename()) + ctx.const.partial_suffix
-        )
+    def __init__(self):
+        self.bandwidth_limit = self._get_bandwidth_limit()
+        self.max_retries = self._get_max_retries()
 
-        util.ensure_dirs(self.destdir)
+        self.session = requests.Session()
 
-    def fetch(self):
-        """Return value: Fetched file's full path.."""
+        self.session.mount("http://", HTTPAdapter(max_retries=self.max_retries))
+        self.session.mount("https://", HTTPAdapter(max_retries=self.max_retries))
+        self.session.headers.update({"User-Agent": f"eopkg Fetcher/{pisi.__version__}"})
 
-        if not self.url.filename():
-            raise FetchError(_("Filename error"))
+        proxies = self._get_proxies()
+        self.session.proxies.update(proxies)
 
-        if not os.access(self.destdir, os.W_OK):
-            raise FetchError(
-                _('Access denied to write to destination directory: "%s"')
-                % self.destdir
-            )
+    def download_file(self, url: str, destination: str) -> None:
+        """
+        Download a remote resource to a local file.
 
-        if os.path.exists(self.archive_file) and not os.access(
-            self.archive_file, os.W_OK
-        ):
-            raise FetchError(
-                _('Access denied to destination file: "%s"') % self.archive_file
-            )
+        :param str url: The URL of the resource to download.
+        :param str destination: The destination file to download to.
+        """
+        with self.session.get(url.get_uri(), stream=True, timeout=15) as resp:
+            resp.raise_for_status()
+            start_time = time.time()
 
-        attempt = 0
-        success = False
+            total = int(resp.headers.get("Content-Length"), 0)
 
-        self.now = lambda: time.time()
-        self.start_time = self.now()
+            with (
+                open(destination, "wb") as f,
+                tqdm(
+                    desc=destination,
+                    total=total,
+                    unit="iB",
+                    unit_scale=True,
+                    unit_divisor=1024,
+                ) as bar,
+            ):
+                for chunk in resp.iter_content(chunk_size=MAX_CHUNK_SIZE):
+                    if not chunk:
+                        # TODO(Evan): Figure out what to do here
+                        break
 
-        while success is False and attempt < self._get_retry_attempts() + 1:
-            try:
-                fetch_handler = FetchHandler(
-                    self.url,
-                    self.partial_file,
-                    self._get_bandwidth_limit(),
-                    self.start_time,
-                )
+                    size = f.write(chunk)
+                    bar.update(size)
 
-                proxy = urllib.request.ProxyHandler(self._get_proxies())
-                opener = urllib.request.build_opener(proxy)
-                opener.addheaders = self._get_headers()
-                urllib.request.install_opener(opener)
-                has_range_support = self._test_range_support()
+                    # Handle bandwidth limiting, if set
+                    if self.bandwidth_limit:
+                        elapsed = time.time() - start_time
+                        # Calculate the time this chunk "should" take to stay
+                        # under the limit
+                        expected_time = MAX_CHUNK_SIZE / self.bandwidth_limit
 
-                if has_range_support and os.path.exists(self.partial_file):
-                    partial_file_size = os.path.getsize(self.partial_file)
-                    opener.addheaders.append(("Range", "bytes=%s-" % partial_file_size))
+                        # Sleep the difference
+                        if elapsed < expected_time:
+                            time.sleep(expected_time - elapsed)
 
-                with contextlib.closing(
-                    urllib.request.urlopen(self.url.get_uri(), timeout=15)
-                ) as fp:
-                    headers = fp.info()
+    def fetch(self, url: URI | str, dest_dir: str, filename: str = None) -> None:
+        """
+        Fetches a remote resource.
 
-                    if self.url.is_local_file():
-                        return os.path.normpath(self.url.path())
+        :param url: The file to fetch.
+        :type url: pisi.uri.URI | str
+        :param str dest_dir: The directory to save the downloaded file to.
+        :param filename: The name of the file to use.
+        :type filename: str | None
+        """
+        # This is silly and I hate it.
+        if type(url) is str:
+            url = URI(url)
 
-                    if has_range_support:
-                        tfp = open(self.partial_file, "ab")
-                    else:
-                        tfp = open(self.partial_file, "wb")
+        if not url.filename():
+            raise ValueError(_("URL does not end in a file name"))
 
-                    with tfp:
-                        bs = 1024 * 8
-                        size = -1
-                        read = 0
-                        blocknum = 0
-                        if "content-length" in headers:
-                            size = int(headers["Content-Length"])
-                        fetch_handler.update(blocknum, bs, size)
-                        while True:
-                            block = fp.read(bs)
-                            if not block:
-                                break
-                            read += len(block)
-                            tfp.write(block)
-                            blocknum += 1
-                            fetch_handler.update(blocknum, bs, size)
-                    success = True
-            except URLError as e:
-                attempt += 1
-                if attempt == self._get_retry_attempts() + 1:
-                    raise FetchError(
-                        _('Hit max retry count when downloading: "%s"')
-                        % (self.url.get_uri())
-                    )
-                ctx.ui.warning(
-                    _('\nFailed to fetch file, retrying %d out of %d "%s": %s')
-                    % (attempt, self._get_retry_attempts(), self.url.get_uri(), e)
-                )
-                pass
+        if not os.access(dest_dir, os.W_OK):
+            raise IOError(_(f"Unable to access destination directory '{dest_dir}'"))
 
-        if os.stat(self.partial_file).st_size == 0:
-            os.remove(self.partial_file)
-            raise FetchError(
-                _(
-                    "A problem occurred. Please check the archive address and/or permissions again."
-                )
-            )
+        archive_file = os.path.join(dest_dir, filename or url.filename())
 
-        shutil.move(self.partial_file, self.archive_file)
+        if os.path.exists(archive_file) and not os.access(archive_file, os.W_OK):
+            raise IOError(_(f"Unable to access destination file '{archive_file}'"))
 
-        return self.archive_file
+        try:
+            self.download_file(url, archive_file)
+        except HTTPError:
+            raise
 
-    def _get_headers(self):
-        headers = []
-        headers.append(("User-Agent", "eopkg Fetcher/" + pisi.__version__))
-        return headers
-
-    def _get_proxies(self):
-        proxies = {}
-
-        if ctx.config.values.general.http_proxy and self.url.scheme() == "http":
-            proxies[pisi.uri.URI(ctx.config.values.general.http_proxy).scheme()] = (
-                ctx.config.values.general.http_proxy
-            )
-
-        if ctx.config.values.general.https_proxy and self.url.scheme() == "https":
-            proxies[pisi.uri.URI(ctx.config.values.general.https_proxy).scheme()] = (
-                ctx.config.values.general.https_proxy
-            )
-
-        if ctx.config.values.general.ftp_proxy and self.url.scheme() == "ftp":
-            proxies[pisi.uri.URI(ctx.config.values.general.ftp_proxy).scheme()] = (
-                ctx.config.values.general.ftp_proxy
-            )
-
-        if self.url.scheme() in proxies:
-            ctx.ui.info(
-                _("Proxy configuration has been found for '%s' protocol")
-                % self.url.scheme()
-            )
-
-        return proxies
-
-    def _get_bandwidth_limit(self):
+    def _get_bandwidth_limit(self) -> int:
         bandwidth_limit = (
             ctx.config.options.bandwidth_limit
             or ctx.config.values.general.bandwidth_limit
         )
+
+        # TODO(Evan): Figure out if there's a mismatch between config units
+        # and units used to calculate the limiter
         if bandwidth_limit and bandwidth_limit != "0":
-            ctx.ui.warning(_("Bandwidth usage is limited to %s KB/s") % bandwidth_limit)
+            ctx.ui.warning(_(f"Bandwidth usage is limited to {bandwidth_limit} KB/s"))
             return 1024 * int(bandwidth_limit)
         else:
             return 0
 
-    def _get_retry_attempts(self):
+    def _get_max_retries(self) -> int:
         retry_attempts = (
             ctx.config.options.retry_attempts
             or ctx.config.values.general.retry_attempts
         )
+
         if retry_attempts and retry_attempts != "5":
             return int(retry_attempts)
         else:
             return 5
 
-    def _test_range_support(self):
-        if not os.path.exists(self.partial_file):
-            return False
+    def _get_proxies(self) -> dict:
+        proxies = {}
 
-        try:
-            file_obj = urllib.request.urlopen(
-                urllib.request.Request(self.url.get_uri())
-            )
-        except urllib.error.URLError:
-            ctx.ui.debug(
-                _(
-                    "Remote file can not be reached. Previously downloaded part of the file will be removed."
-                )
-            )
-            os.remove(self.partial_file)
-            return False
+        if ctx.config.values.general.http_proxy and self.url.scheme() == "http":
+            proxies["http"] = ctx.config.values.general.http_proxy
 
-        headers = file_obj.info()
-        file_obj.close()
-        if "Content-Length" in headers:
-            return True
-        else:
-            ctx.ui.debug(
-                _(
-                    "Server doesn't support partial downloads. Previously downloaded part of the file will be over-written."
-                )
-            )
-            os.remove(self.partial_file)
-            return False
+        if ctx.config.values.general.https_proxy and self.url.scheme() == "https":
+            proxies["https"] = ctx.config.values.general.https_proxy
 
+        if ctx.config.values.general.ftp_proxy and self.url.scheme() == "ftp":
+            proxies["ftp"] = ctx.config.values.general.ftp_proxy
 
-# helper function
-def fetch_url(url, destdir, progress=None, destfile=None):
-    fetch = Fetcher(url, destdir, destfile)
-    fetch.progress = progress
-    fetch.fetch()
+        return proxies

--- a/pisi/fetcher.py
+++ b/pisi/fetcher.py
@@ -63,7 +63,7 @@ class Fetcher:
             resp.raise_for_status()
             start_time = time.time()
 
-            total = int(resp.headers.get("Content-Length"), 0)
+            total = int(resp.headers.get("Content-Length") or 0)
 
             with (
                 open(destination, "wb") as f,
@@ -96,10 +96,11 @@ class Fetcher:
                             time.sleep(expected_time - elapsed)
 
     def fetch(
-        self, url: URI | str,
+        self,
+        url: URI | str,
         dest_dir: str,
         filename: str = None,
-        progress_bar_pos: int = 0
+        progress_bar_pos: int = 0,
     ) -> None:
         """
         Fetches a remote resource.

--- a/pisi/file.py
+++ b/pisi/file.py
@@ -15,11 +15,11 @@ import shutil
 import lzma_mt
 
 import pisi
-import pisi.fetcher
 import pisi.uri
 import pisi.util
 from pisi import context as ctx
 from pisi import translate as _
+from pisi.fetcher import Fetcher
 
 
 class AlreadyHaveException(pisi.Exception):
@@ -139,8 +139,10 @@ class File:
                     raise AlreadyHaveException(uri, origfile)
 
             if uri.is_remote_file():
-                ctx.ui.info(_("Fetching %s") % uri.get_uri(), verbose=True)
-                pisi.fetcher.fetch_url(uri, transfer_dir, ctx.ui.Progress, tmpfile)
+                ctx.ui.info(_(f"Fetching {uri.get_uri}"), verbose=True)
+                fetcher = Fetcher()
+                # TODO(Evan): Error handling
+                fetcher.fetch(uri, transfer_dir, tmpfile)
             else:
                 # copy to transfer dir
                 ctx.ui.info(

--- a/pisi/operations/build.py
+++ b/pisi/operations/build.py
@@ -12,6 +12,8 @@ import pwd
 import grp
 import fnmatch
 
+from requests import HTTPError
+
 from pisi import translate as _
 
 import pisi
@@ -23,14 +25,13 @@ import pisi.dependency as dependency
 import pisi.api
 import pisi.sourcearchive
 import pisi.files
-import pisi.fetcher
 import pisi.uri
 import pisi.metadata
 import pisi.package
 import pisi.component as component
-import pisi.archive as archive
 import pisi.actionsapi.variables
 import pisi.db
+from pisi.fetcher import Fetcher
 
 import magic
 
@@ -382,10 +383,7 @@ class Builder:
                 ctx.ui.info(_("ccache detected..."))
             if self.has_icecream:
                 ctx.ui.info(
-                    _(
-                        "IceCream detected. Make sure your daemon "
-                        "is up and running..."
-                    )
+                    _("IceCream detected. Make sure your daemon is up and running...")
                 )
 
             self.run_setup_action()
@@ -530,11 +528,14 @@ class Builder:
         diruri = util.parenturi(self.specuri.get_uri())
         parentdir = util.parenturi(diruri)
         url = util.join_path(parentdir, "component.xml")
-        progress = ctx.ui.Progress
+
         if pisi.uri.URI(url).is_remote_file():
+            fetcher = Fetcher()
+
+            # TODO(Evan): wat
             try:
-                pisi.fetcher.fetch_url(url, self.pkg_work_dir(), progress)
-            except pisi.fetcher.FetchError:
+                fetcher.fetch(url, self.pkg_work_dir())
+            except HTTPError | IOError | ValueError:
                 ctx.ui.warning(
                     _(
                         "Cannot find component.xml in remote "
@@ -811,16 +812,13 @@ class Builder:
 
                 if not path.startswith("/"):
                     raise Error(
-                        _(
-                            "Source package '%s' defines a relative 'Path' element: "
-                            "%s"
-                        )
+                        _("Source package '%s' defines a relative 'Path' element: %s")
                         % (self.spec.source.name, path_info.path)
                     )
 
                 if path in paths:
                     raise Error(
-                        _("Source package '%s' defines multiple 'Path' tags " "for %s")
+                        _("Source package '%s' defines multiple 'Path' tags for %s")
                         % (self.spec.source.name, path_info.path)
                     )
 
@@ -1562,15 +1560,14 @@ class Builder:
                         os.chown(dest, pwd.getpwnam(afile.owner)[2], -1)
                     except KeyError:
                         ctx.ui.warning(
-                            _("No user named '%s' found " "on the system") % afile.owner
+                            _("No user named '%s' found on the system") % afile.owner
                         )
                 if afile.group:
                     try:
                         os.chown(dest, -1, grp.getgrnam(afile.group)[2])
                     except KeyError:
                         ctx.ui.warning(
-                            _("No group named '%s' found " "on the system")
-                            % afile.group
+                            _("No group named '%s' found on the system") % afile.group
                         )
         os.chdir(c)
 
@@ -1578,8 +1575,7 @@ class Builder:
         abandoned_files = self.get_abandoned_files()
         if abandoned_files:
             ctx.ui.error(
-                _("There are abandoned files " "under the install dir (%s):")
-                % install_dir
+                _("There are abandoned files under the install dir (%s):") % install_dir
             )
 
             for f in abandoned_files:

--- a/pisi/operations/helper.py
+++ b/pisi/operations/helper.py
@@ -4,15 +4,16 @@
 import os
 
 from ordered_set import OrderedSet as set
-from pisi import translate as _
-from pisi import Error
 
 import pisi
-import pisi.context as ctx
-import pisi.util as util
-import pisi.ui as ui
 import pisi.conflict
+import pisi.context as ctx
 import pisi.db
+import pisi.fetcher
+import pisi.ui as ui
+import pisi.util as util
+from pisi import Error
+from pisi import translate as _
 
 
 def reorder_base_packages_old(order):
@@ -114,9 +115,20 @@ def extract_automatic(A, total):
 
 
 def calculate_download_sizes(order):
-    download_info = get_download_info(order)
-    total_size = sum(info["size"] for info in download_info)
-    cached_size = sum(info["cached_size"] for info in download_info)
+    packagedb = pisi.db.packagedb.PackageDB()
+    resources = [packagedb.get_resource(name) for name in order]
+
+    total_size = sum(r.size for r in resources)
+    cached_size = 0
+    for r in resources:
+        if os.path.exists(r.local_path):
+            if util.sha1_file(r.local_path) == r.expected_hash:
+                cached_size += r.size
+            else:
+                # partial download?
+                part_path = r.local_path + ".part"
+                if os.path.exists(part_path):
+                    cached_size += os.stat(part_path).st_size
 
     ctx.ui.notify(ui.cached, total=total_size, cached=cached_size)
     return total_size, cached_size
@@ -124,101 +136,32 @@ def calculate_download_sizes(order):
 
 def get_download_info(order):
     """
-    Returns a list of dicts containing download info for each package in order.
+    Returns a list of PackageResource objects for each package in order.
     """
-    download_info = []
-    installdb = pisi.db.installdb.InstallDB()
     packagedb = pisi.db.packagedb.PackageDB()
-    repodb = pisi.db.repodb.RepoDB()
-
-    try:
-        cached_packages_dir = ctx.config.cached_packages_dir()
-    except OSError:
-        # happens when cached_packages_dir tried to be created by an unpriviledged user
-        cached_packages_dir = None
-
-    for name in order:
-        repo_name = packagedb.which_repo(name)
-        if not repo_name:
-            raise Error(_("Package %s not found in any active repository.") % name)
-
-        repo = repodb.get_repo(repo_name)
-        pkg = packagedb.get_package(name)
-        delta = None
-
-        if installdb.has_package(pkg.name):
-            (
-                version,
-                release,
-                build,
-                distro,
-                distro_release,
-            ) = installdb.get_version_and_distro_release(pkg.name)
-            if distro_release == pkg.distributionRelease:
-                delta = pkg.get_delta(release)
-
-        ignore_delta = ctx.config.values.general.ignore_delta
-
-        if delta and not ignore_delta:
-            pkg_uri_str = delta.packageURI
-            pkg_hash = delta.packageHash
-            pkg_size = delta.packageSize
-        else:
-            pkg_uri_str = pkg.packageURI
-            pkg_hash = pkg.packageHash
-            pkg_size = pkg.packageSize
-
-        uri = pisi.uri.URI(pkg_uri_str)
-        if not uri.is_absolute_path():
-            pkg_uri_str = os.path.join(
-                os.path.dirname(repo.indexuri.get_uri()), str(uri.path())
-            )
-
-        uri = pisi.uri.URI(pkg_uri_str)
-
-        info = {
-            "name": name,
-            "uri": uri,
-            "hash": pkg_hash,
-            "size": pkg_size,
-        }
-
-        if cached_packages_dir and uri.is_remote_file():
-            path = util.join_path(cached_packages_dir, uri.filename())
-            # check the file and sha1sum to be sure it _is_ the cached package
-            if os.path.exists(path) and util.sha1_file(path) == pkg_hash:
-                info["cached"] = True
-                info["cached_size"] = pkg_size
-            else:
-                info["cached"] = False
-                part_path = "%s.part" % path
-                if os.path.exists(part_path):
-                    info["cached_size"] = os.stat(part_path).st_size
-                else:
-                    info["cached_size"] = 0
-        else:
-            info["cached"] = not uri.is_remote_file()
-            info["cached_size"] = pkg_size if info["cached"] else 0
-
-        download_info.append(info)
-
-    return download_info
+    return [packagedb.get_resource(name) for name in order]
 
 
 def fetch_packages(order):
     """
     Fetches all packages in order concurrently if they are not already cached.
     """
-    download_info = get_download_info(order)
+    resources = get_download_info(order)
     items_to_fetch = []
-    cached_packages_dir = ctx.config.cached_packages_dir()
 
-    for info in download_info:
-        if not info["cached"] and info["uri"].is_remote_file():
+    for r in resources:
+        if r.uri.is_remote_file():
+            # Check if it's already cached and valid
+            if (
+                os.path.exists(r.local_path)
+                and util.sha1_file(r.local_path) == r.expected_hash
+            ):
+                continue
+
             items_to_fetch.append(
-                (info["uri"], cached_packages_dir, info["uri"].filename())
+                (r.uri, os.path.dirname(r.local_path), r.uri.filename())
             )
 
     if items_to_fetch:
-        fetcher = Fetcher()
+        fetcher = pisi.fetcher.Fetcher()
         fetcher.fetch_multi(items_to_fetch)

--- a/pisi/operations/helper.py
+++ b/pisi/operations/helper.py
@@ -114,10 +114,22 @@ def extract_automatic(A, total):
 
 
 def calculate_download_sizes(order):
-    total_size = cached_size = 0
+    download_info = get_download_info(order)
+    total_size = sum(info["size"] for info in download_info)
+    cached_size = sum(info["cached_size"] for info in download_info)
 
+    ctx.ui.notify(ui.cached, total=total_size, cached=cached_size)
+    return total_size, cached_size
+
+
+def get_download_info(order):
+    """
+    Returns a list of dicts containing download info for each package in order.
+    """
+    download_info = []
     installdb = pisi.db.installdb.InstallDB()
     packagedb = pisi.db.packagedb.PackageDB()
+    repodb = pisi.db.repodb.RepoDB()
 
     try:
         cached_packages_dir = ctx.config.cached_packages_dir()
@@ -125,8 +137,15 @@ def calculate_download_sizes(order):
         # happens when cached_packages_dir tried to be created by an unpriviledged user
         cached_packages_dir = None
 
-    for pkg in [packagedb.get_package(name) for name in order]:
+    for name in order:
+        repo_name = packagedb.which_repo(name)
+        if not repo_name:
+            raise Error(_("Package %s not found in any active repository.") % name)
+
+        repo = repodb.get_repo(repo_name)
+        pkg = packagedb.get_package(name)
         delta = None
+
         if installdb.has_package(pkg.name):
             (
                 version,
@@ -141,23 +160,65 @@ def calculate_download_sizes(order):
         ignore_delta = ctx.config.values.general.ignore_delta
 
         if delta and not ignore_delta:
-            fn = os.path.basename(delta.packageURI)
+            pkg_uri_str = delta.packageURI
             pkg_hash = delta.packageHash
             pkg_size = delta.packageSize
         else:
-            fn = os.path.basename(pkg.packageURI)
+            pkg_uri_str = pkg.packageURI
             pkg_hash = pkg.packageHash
             pkg_size = pkg.packageSize
 
-        if cached_packages_dir:
-            path = util.join_path(cached_packages_dir, fn)
+        uri = pisi.uri.URI(pkg_uri_str)
+        if not uri.is_absolute_path():
+            pkg_uri_str = os.path.join(
+                os.path.dirname(repo.indexuri.get_uri()), str(uri.path())
+            )
+
+        uri = pisi.uri.URI(pkg_uri_str)
+
+        info = {
+            "name": name,
+            "uri": uri,
+            "hash": pkg_hash,
+            "size": pkg_size,
+        }
+
+        if cached_packages_dir and uri.is_remote_file():
+            path = util.join_path(cached_packages_dir, uri.filename())
             # check the file and sha1sum to be sure it _is_ the cached package
             if os.path.exists(path) and util.sha1_file(path) == pkg_hash:
-                cached_size += pkg_size
-            elif os.path.exists("%s.part" % path):
-                cached_size += os.stat("%s.part" % path).st_size
+                info["cached"] = True
+                info["cached_size"] = pkg_size
+            else:
+                info["cached"] = False
+                part_path = "%s.part" % path
+                if os.path.exists(part_path):
+                    info["cached_size"] = os.stat(part_path).st_size
+                else:
+                    info["cached_size"] = 0
+        else:
+            info["cached"] = not uri.is_remote_file()
+            info["cached_size"] = pkg_size if info["cached"] else 0
 
-        total_size += pkg_size
+        download_info.append(info)
 
-    ctx.ui.notify(ui.cached, total=total_size, cached=cached_size)
-    return total_size, cached_size
+    return download_info
+
+
+def fetch_packages(order):
+    """
+    Fetches all packages in order concurrently if they are not already cached.
+    """
+    download_info = get_download_info(order)
+    items_to_fetch = []
+    cached_packages_dir = ctx.config.cached_packages_dir()
+
+    for info in download_info:
+        if not info["cached"] and info["uri"].is_remote_file():
+            items_to_fetch.append(
+                (info["uri"], cached_packages_dir, info["uri"].filename())
+            )
+
+    if items_to_fetch:
+        fetcher = Fetcher()
+        fetcher.fetch_multi(items_to_fetch)

--- a/pisi/operations/history.py
+++ b/pisi/operations/history.py
@@ -2,18 +2,17 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 import os
-import gettext
-
-__trans = gettext.translation("pisi", fallback=True)
-_ = __trans.gettext
 
 from ordered_set import OrderedSet as set
+
+from requests import HTTPError
 
 import pisi
 import pisi.context as ctx
 import pisi.util
 import pisi.db
-import pisi.fetcher
+from pisi import translate as _
+from pisi.fetcher import Fetcher
 
 
 class PackageNotFound(pisi.Error):
@@ -99,7 +98,7 @@ def __getpackageurl(package):
     return os.path.join(os.path.dirname(repourl), package)
 
 
-def fetch_remote_file(package, errors):
+def fetch_remote_file(fetcher, package, errors):
     try:
         uri = pisi.file.File.make_uri(__getpackageurl_binman(package))
     except PackageNotFound:
@@ -109,20 +108,18 @@ def fetch_remote_file(package, errors):
 
     dest = ctx.config.cached_packages_dir()
     filepath = os.path.join(dest, uri.filename())
+    # TODO(Evan): Validate
     if not os.path.exists(filepath):
-        failed = False
         try:
-            pisi.fetcher.fetch_url(uri, dest, ctx.ui.Progress)
-        except pisi.fetcher.FetchError as e:
-            failed = True
-        if failed:
+            fetcher.fetch(uri, dest)
+        except HTTPError | IOError | ValueError:
             try:
                 new_uri = pisi.file.File.make_uri(__getpackageurl(package))
-                pisi.fetcher.fetch_url(new_uri, dest, ctx.ui.Progress)
-            except:
+                fetcher.fetch(new_uri, dest)
+            except HTTPError | IOError | ValueError:
                 errors.append(package)
                 ctx.ui.info(
-                    pisi.util.colorize(_("%s could not be found") % (package), "red")
+                    pisi.util.colorize(_(f"{package} could not be found"), "red")
                 )
                 return False
     else:
@@ -176,6 +173,7 @@ def plan_takeback(operation):
 def takeback(operation):
     historydb = pisi.db.historydb.HistoryDB()
     beinstalled, beremoved, configs = plan_takeback(operation)
+    fetcher = Fetcher()
 
     if beinstalled:
         ctx.ui.info(
@@ -202,7 +200,7 @@ def takeback(operation):
             )
         )
         pkg += ctx.const.package_suffix
-        if fetch_remote_file(pkg, errors):
+        if fetch_remote_file(fetcher, pkg, errors):
             paths.append(os.path.join(ctx.config.cached_packages_dir(), pkg))
 
     if errors:

--- a/pisi/operations/history.py
+++ b/pisi/operations/history.py
@@ -98,35 +98,6 @@ def __getpackageurl(package):
     return os.path.join(os.path.dirname(repourl), package)
 
 
-def fetch_remote_file(fetcher, package, errors):
-    try:
-        uri = pisi.file.File.make_uri(__getpackageurl_binman(package))
-    except PackageNotFound:
-        errors.append(package)
-        ctx.ui.info(pisi.util.colorize(_("%s could not be found") % (package), "red"))
-        return False
-
-    dest = ctx.config.cached_packages_dir()
-    filepath = os.path.join(dest, uri.filename())
-    # TODO(Evan): Validate
-    if not os.path.exists(filepath):
-        try:
-            fetcher.fetch(uri, dest)
-        except HTTPError | IOError | ValueError:
-            try:
-                new_uri = pisi.file.File.make_uri(__getpackageurl(package))
-                fetcher.fetch(new_uri, dest)
-            except HTTPError | IOError | ValueError:
-                errors.append(package)
-                ctx.ui.info(
-                    pisi.util.colorize(_(f"{package} could not be found"), "red")
-                )
-                return False
-    else:
-        ctx.ui.info(_("%s [cached]") % uri.filename())
-    return True
-
-
 def get_snapshot_actions(operation):
     actions = {}
     snapshot_pkgs = set()
@@ -191,17 +162,40 @@ def takeback(operation):
 
     errors = []
     paths = []
-    for pkg in beinstalled:
-        ctx.ui.info(
-            pisi.util.colorize(
-                _("Downloading %d / %d")
-                % (beinstalled.index(pkg) + 1, len(beinstalled)),
-                "yellow",
-            )
-        )
-        pkg += ctx.const.package_suffix
-        if fetch_remote_file(fetcher, pkg, errors):
-            paths.append(os.path.join(ctx.config.cached_packages_dir(), pkg))
+    fetch_items = []
+
+    for pkg_name in beinstalled:
+        pkg_file = pkg_name + ctx.const.package_suffix
+        try:
+            uri = pisi.file.File.make_uri(__getpackageurl_binman(pkg_file))
+        except PackageNotFound:
+            try:
+                uri = pisi.file.File.make_uri(__getpackageurl(pkg_file))
+            except PackageNotFound:
+                errors.append(pkg_name)
+                ctx.ui.info(
+                    pisi.util.colorize(_("%s could not be found") % (pkg_name), "red")
+                )
+                continue
+
+        dest = ctx.config.cached_packages_dir()
+        filepath = os.path.join(dest, uri.filename())
+
+        if not os.path.exists(filepath):
+            fetch_items.append((uri, dest, uri.filename()))
+        else:
+            ctx.ui.info(_("%s [cached]") % uri.filename())
+            paths.append(filepath)
+
+    if fetch_items:
+        ctx.ui.status(_("Downloading historical packages..."))
+        try:
+            fetcher.fetch_multi(fetch_items)
+            for item in fetch_items:
+                paths.append(os.path.join(item[1], item[2]))
+        except Exception as e:
+            ctx.ui.error(_("Error while fetching historical packages: %s") % str(e))
+            # We might still have some packages, but maybe it's safer to stop or ask.
 
     if errors:
         ctx.ui.info(

--- a/pisi/operations/install.py
+++ b/pisi/operations/install.py
@@ -119,15 +119,14 @@ def install_pkg_names(packages, reinstall=False):
 
     ctx.ui.notify(ui.packagestogo, order=order)
 
+    # Fetch packages concurrently
+    operations.helper.fetch_packages(order)
+
     automatic = operations.helper.extract_automatic(packages, order)
     paths = []
     for package in order:
-        ctx.ui.info(
-            util.colorize(
-                _("Downloading %d / %d") % (order.index(package) + 1, len(order)), "yellow"
-            )
-        )
         install_op = atomicoperations.Install.from_name(package)
+
         paths.append(install_op.package_fname)
 
     ctx.ui.status(_("Finished downloading packages."))

--- a/pisi/operations/install.py
+++ b/pisi/operations/install.py
@@ -119,15 +119,21 @@ def install_pkg_names(packages, reinstall=False):
 
     ctx.ui.notify(ui.packagestogo, order=order)
 
+    # Resolve resources
+    resources = operations.helper.get_download_info(order)
+
     # Fetch packages concurrently
     operations.helper.fetch_packages(order)
 
-    automatic = operations.helper.extract_automatic(packages, order)
-    paths = []
-    for package in order:
-        install_op = atomicoperations.Install.from_name(package)
-
-        paths.append(install_op.package_fname)
+    # Verify hashes and instantiate Install objects
+    install_ops = []
+    for r in resources:
+        if util.sha1_file(r.local_path) != r.expected_hash:
+            raise Error(
+                _("Download Error: Package %s does not match the repository package.")
+                % r.name
+            )
+        install_ops.append(atomicoperations.Install(r.local_path))
 
     ctx.ui.status(_("Finished downloading packages."))
 
@@ -146,15 +152,16 @@ def install_pkg_names(packages, reinstall=False):
     ctx.ui.info(_("Disabling keyboard interrupts for file operations."))
     signal_handler.disable_signal(signal.SIGINT)
 
+    automatic = operations.helper.extract_automatic(packages, order)
+
     try:
-        for path in paths:
+        for i, install_op in enumerate(install_ops):
             ctx.ui.info(
                 util.colorize(
-                    _("Installing %d / %d") % (paths.index(path) + 1, len(paths)),
+                    _("Installing %d / %d") % (i + 1, len(install_ops)),
                     "yellow",
                 )
             )
-            install_op = atomicoperations.Install(path)
             if install_op.pkginfo.name in automatic:
                 install_op.automatic = True
             install_op.install(False)

--- a/pisi/operations/upgrade.py
+++ b/pisi/operations/upgrade.py
@@ -204,25 +204,34 @@ def upgrade(packages = [], repo = None):
 
     ctx.ui.notify(ui.packagestogo, order=order)
 
+    # Resolve resources
+    resources = operations.helper.get_download_info(order)
+
     # Fetch packages concurrently
     operations.helper.fetch_packages(order)
 
-    # Detect package conflicts
-    conflicts = []
-    if not ctx.get_option("ignore_package_conflicts"):
-        conflicts = operations.helper.check_conflicts(order, packagedb)
-
-    automatic = operations.helper.extract_automatic(packages, order)
-    paths = []
-    for x in order:
-        install_op = atomicoperations.Install.from_name(x)
-        paths.append(install_op.package_fname)
+    # Verify hashes and instantiate Install objects
+    install_ops = []
+    for r in resources:
+        if util.sha1_file(r.local_path) != r.expected_hash:
+            raise Error(
+                _("Download Error: Package %s does not match the repository package.")
+                % r.name
+            )
+        install_ops.append(
+            atomicoperations.Install(r.local_path, ignore_file_conflicts=True)
+        )
 
     ctx.ui.status(_("Finished downloading package upgrades."))
 
     # Don't actually install if --fetch-only was set
     if ctx.get_option("fetch_only"):
         return True
+
+    # Detect package conflicts
+    conflicts = []
+    if not ctx.get_option("ignore_package_conflicts"):
+        conflicts = operations.helper.check_conflicts(order, packagedb)
 
     # Handle package conflicts
     if conflicts:
@@ -234,15 +243,16 @@ def upgrade(packages = [], repo = None):
     ctx.ui.info(_("Disabling keyboard interrupts for file operations."))
     signal_handler.disable_signal(signal.SIGINT)
 
+    automatic = operations.helper.extract_automatic(packages, order)
+
     try:
-        for path in paths:
+        for i, install_op in enumerate(install_ops):
             ctx.ui.info(
                 util.colorize(
-                    _("Installing %d / %d") % (paths.index(path) + 1, len(paths)),
+                    _("Installing %d / %d") % (i + 1, len(install_ops)),
                     "yellow",
                 )
             )
-            install_op = atomicoperations.Install(path, ignore_file_conflicts=True)
             if install_op.pkginfo.name in automatic:
                 install_op.automatic = True
             install_op.install(True)

--- a/pisi/operations/upgrade.py
+++ b/pisi/operations/upgrade.py
@@ -204,6 +204,9 @@ def upgrade(packages = [], repo = None):
 
     ctx.ui.notify(ui.packagestogo, order=order)
 
+    # Fetch packages concurrently
+    operations.helper.fetch_packages(order)
+
     # Detect package conflicts
     conflicts = []
     if not ctx.get_option("ignore_package_conflicts"):
@@ -212,11 +215,6 @@ def upgrade(packages = [], repo = None):
     automatic = operations.helper.extract_automatic(packages, order)
     paths = []
     for x in order:
-        ctx.ui.info(
-            util.colorize(
-                _("Downloading %d / %d") % (order.index(x) + 1, len(order)), "yellow"
-            )
-        )
         install_op = atomicoperations.Install.from_name(x)
         paths.append(install_op.package_fname)
 

--- a/pisi/package.py
+++ b/pisi/package.py
@@ -61,10 +61,6 @@ class Package:
         self.files = None
         self.repo = None
 
-        url = pisi.uri.URI(packagefn)
-        if url.is_remote_file():
-            self.fetch_remote_file(url)
-
         try:
             self.impl = archive.ArchiveZip(self.filepath, "zip", mode)
         except IOError as e:
@@ -92,34 +88,6 @@ class Package:
             raise Error(_("Unsupported package format: %s") % format)
 
         self.tmp_dir = tmp_dir or ctx.config.tmp_dir()
-
-    def fetch_remote_file(self, url):
-        dest = ctx.config.cached_packages_dir()
-        self.filepath = os.path.join(dest, url.filename())
-
-        # So we can emit a notify event with the package info
-        pkg_name, pkg_version = pisi.util.parse_package_name(url.filename())
-        self.metadata, self.files, self.repo = pisi.api.info_name(pkg_name, False)
-
-        if not os.path.exists(self.filepath):
-            try:
-                ctx.ui.notify(
-                    pisi.ui.downloading, package=self.metadata.package, files=self.files
-                )
-                pisi.file.File.download(url, dest)
-            except pisi.fetcher.FetchError:
-                # Bug 3465
-                if ctx.get_option("reinstall"):
-                    raise Error(
-                        _(
-                            "There was a problem while fetching '%s'.\nThe package "
-                            "may have been upgraded. Please try to upgrade the package."
-                        )
-                        % url
-                    )
-                raise
-        else:
-            ctx.ui.info(_("%s [cached]") % url.filename())
 
     def add_to_package(self, fn, an=None):
         """Add a file or directory to package"""

--- a/pisi/package.py
+++ b/pisi/package.py
@@ -22,6 +22,16 @@ class Error(pisi.Error):
     pass
 
 
+class PackageResource:
+    def __init__(self, name, uri, expected_hash, size, local_path, is_delta=False):
+        self.name = name
+        self.uri = uri
+        self.expected_hash = expected_hash
+        self.size = size
+        self.local_path = local_path
+        self.is_delta = is_delta
+
+
 class Package:
     """eopkg Package Class provides access to a pisi package (.pisi
     file)."""

--- a/pisi/sourcearchive.py
+++ b/pisi/sourcearchive.py
@@ -4,6 +4,9 @@
 # python standard library
 
 import os
+
+from requests import HTTPError
+
 from pisi import translate as _
 
 # pisi modules
@@ -12,8 +15,8 @@ import pisi.util as util
 import pisi.context as ctx
 import pisi.archive
 import pisi.uri
-import pisi.fetcher
 import pisi.mirrors
+from pisi.fetcher import Fetcher
 
 
 class Error(pisi.Error):
@@ -68,11 +71,13 @@ class SourceArchive:
                 % (ctx.config.archives_dir(), self.url.filename())
             )
 
+    # TODO(Evan): WTF
     def fetch_from_mirror(self):
         uri = self.url.get_uri()
         sep = uri[len("mirrors://") :].split("/")
         name = sep.pop(0)
         archive = "/".join(sep)
+        fetcher = Fetcher()
 
         mirrors = pisi.mirrors.Mirrors().get_mirrors(name)
         if not mirrors:
@@ -82,14 +87,12 @@ class SourceArchive:
             try:
                 url = os.path.join(mirror, archive)
                 ctx.ui.warning(_("Fetching source from mirror: %s") % url)
-                pisi.fetcher.fetch_url(url, ctx.config.archives_dir(), self.progress)
+                fetcher.fetch(url, ctx.config.archives_dir())
                 return
-            except pisi.fetcher.FetchError:
+            except HTTPError | IOError | ValueError:
                 pass
 
-        raise pisi.fetcher.FetchError(
-            _("Could not fetch source from %s mirrors.") % name
-        )
+        raise Error(_(f"Could not fetch source from {name} mirrors."))
 
     def is_cached(self, interactive=True):
         if not os.access(self.archiveFile, os.R_OK):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [{ name = "Solus Project", email = "releng@getsol.us" }]
 keywords = ["package", "manager", "management", "solus"]
 classifiers = ["Programming Language :: Python :: 3 :: Only"]
 requires-python = ">=3.8.0"
-dependencies = ["iksemel>=1.6.1", "lzma-mt>=0.1.4", "ordered_set>=4.1.0,<=4.2.0", "python-magic>=0.4.27", "xattr>= 1.1.0"]
+dependencies = ["iksemel>=1.6.1", "lzma-mt>=0.1.4", "ordered_set>=4.1.0,<=4.2.0", "python-magic>=0.4.27", "requests>=2.32.0", "tqdm>=4.67.0", "xattr>= 1.1.0"]
 dynamic = ["version"]
 
 [project.urls]
@@ -22,7 +22,7 @@ uneopkg = "pisi.scripts.uneopkg:main"
 # Builder-specific keys below. We use setuptools.
 
 [build-system]
-requires = ["setuptools>=58.0", "iksemel>=1.6.1", "lzma-mt>=0.1.4", "python-magic>=0.4.27", "ordered_set>=4.1.0,<=4.2.0"]
+requires = ["setuptools>=58.0", "iksemel>=1.6.1", "lzma-mt>=0.1.4", "python-magic>=0.4.27", "ordered_set>=4.1.0,<=4.2.0", "requests>=2.32.0", "tqdm>=4.67.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.dynamic]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,6 @@ jeepney
 lzma_mt
 ordered_set
 python-magic
+requests
+tqdm
 xattr


### PR DESCRIPTION
## Summary

The Python requests library provides a lot or all of the capability of the old fetcher without us having to do it all by hand. This version aims to use modern Python practices, and be far more maintainable.

Instead of each separate fetch call using it's own HTTP session, this implementation stores a session that can be used to make multiple network requests. That has the benefit of reducing overhead, and might make it easier to have multiple downloads going on in parallel in the future.

A lot of the code that uses the fetcher really needs to be looked at closely. Some of them are doing non-obvious things, reached may require more modification to keep them working with the new fetcher.

## Test Plan

In a `venv`, install this version of `eopkg` with `pip install .`. Then, fetch a remote .eopkg with `./eopkg.py3 fetch --debug systemd`.

This will require a *lot* more testing before it is merged and released, especially with the more obscure codepaths. More testers are very desired.
