### PR TITLE
version: Optimize make_version()

### DIFF
--- a/pisi/version.py
+++ b/pisi/version.py
@@ -3,9 +3,8 @@
 
 """version structure"""
 
-from pisi import translate as _
-
 import pisi
+from pisi import translate as _
 
 # Basic rule is:
 # p > (no suffix) > m > rc > pre > beta > alpha
@@ -39,6 +38,8 @@ def __make_version_item(v):
 
 def make_version(version):
     ver, sep, suffix = version.partition("_")
+    ver_parts = ver.split(".")
+    ver_items = [__make_version_item(x) for x in ver_parts]
     try:
         if sep:
             # "s" is a string greater than the greatest keyword "rc"
@@ -46,14 +47,12 @@ def make_version(version):
                 for keyword, value in __keywords:
                     if suffix.startswith(keyword):
                         return (
-                            list(map(__make_version_item, ver.split("."))),
+                            ver_items,
                             value,
-                            list(
-                                map(
-                                    __make_version_item,
-                                    suffix[len(keyword) :].split("."),
-                                )
-                            ),
+                            [
+                                __make_version_item(x)
+                                for x in suffix[len(keyword) :].split(".")
+                            ],
                         )
                 else:
                     # Probably an invalid version string. Reset ver string
@@ -61,12 +60,12 @@ def make_version(version):
                     ver = ""
             else:
                 return (
-                    list(map(__make_version_item, ver.split("."))),
+                    ver_items,
                     0,
-                    list(map(__make_version_item, suffix.split("."))),
+                    [__make_version_item(x) for x in suffix.split(".")],
                 )
 
-        return list(map(__make_version_item, ver.split("."))), 0, [(0, None)]
+        return ver_items, 0, [(0, None)]
 
     except ValueError:
         raise InvalidVersionError(_("Invalid version string: '%s'") % version)


### PR DESCRIPTION
## Summary

Replace list(map()) usage with list comprehension, this provides the majority of the speedup

Calculate the commonly used ver_items and ver_parts only once

ncalls  tottime  percall  cumtime  percall filename:lineno(function)
Before:
25655    0.032    0.000    0.052    0.000 version.py:40(make_version)
Now:
25655    0.023    0.000    0.042    0.000 version.py:39(make_version)

## Test Plan

Test make_version returns the same results as before, use a few common package operations