### PR TITLE
operations/upgrade: Require is_upgradable() to take {Install,Package}DB

### DIFF
--- a/pisi/api.py
+++ b/pisi/api.py
@@ -257,10 +257,13 @@ def list_upgradable():
     Return a list of packages that are upgraded in the repository -> list_of_strings
     """
     installdb = pisi.db.installdb.InstallDB()
+    packagedb = pisi.db.packagedb.PackageDB()
     is_upgradable = pisi.operations.upgrade.is_upgradable
     installed = installdb.list_installed()
 
-    upgradable = [name for name in installed if is_upgradable(name)]
+    upgradable = [
+        name for name in installed if is_upgradable(name, installdb, packagedb)
+    ]
     # replaced packages can not pass is_upgradable test, so we add them manually
     upgradable.extend(list_replaces())
 

--- a/pisi/operations/upgrade.py
+++ b/pisi/operations/upgrade.py
@@ -350,7 +350,7 @@ def plan_upgrade(A, force_replaced=True, replaces=None):
             if rev_dep in G_f.vertices() or depinfo.satisfied_by_repo():
                 continue
 
-            if is_upgradable(rev_dep):
+            if is_upgradable(rev_dep, installdb, packagedb):
                 Bp.add(rev_dep)
                 G_f.add_plain_dep(rev_dep, pkg.name)
 
@@ -364,7 +364,9 @@ def plan_upgrade(A, force_replaced=True, replaces=None):
         if packages:
             for target_package in packages:
                 for name, dep in installdb.get_rev_deps(target_package):
-                    if name in G_f.vertices() or not is_upgradable(name):
+                    if name in G_f.vertices() or not is_upgradable(
+                        name, installdb, packagedb
+                    ):
                         continue
 
                     Bp.add(name)
@@ -396,6 +398,7 @@ def plan_upgrade(A, force_replaced=True, replaces=None):
 
 def upgrade_base(A=set()):
     installdb = pisi.db.installdb.InstallDB()
+    packagedb = pisi.db.packagedb.PackageDB()
     componentdb = pisi.db.componentdb.ComponentDB()
     if not ctx.config.values.general.ignore_safety and not ctx.get_option(
         "ignore_safety"
@@ -410,14 +413,16 @@ def upgrade_base(A=set()):
             )
             if extra_installs:
                 ctx.ui.warning(
-                    _("Safety switch forces the installation of " "following packages:")
+                    _("Safety switch forces the installation of following packages:")
                 )
                 ctx.ui.info(util.format_by_columns(sorted(extra_installs)))
             G_f, install_order = operations.install.plan_install_pkg_names(
                 extra_installs
             )
             extra_upgrades = [
-                x for x in systembase - set(install_order) if is_upgradable(x)
+                x
+                for x in systembase - set(install_order)
+                if is_upgradable(x, installdb, packagedb)
             ]
             upgrade_order = []
 
@@ -457,8 +462,11 @@ def upgrade_base(A=set()):
     return set()
 
 
-def is_upgradable(name):
-    installdb = pisi.db.installdb.InstallDB()
+def is_upgradable(
+    name: str,
+    installdb: pisi.db.installdb.InstallDB,
+    packagedb: pisi.db.packagedb.PackageDB,
+):
 
     if not installdb.has_package(name):
         return False
@@ -470,8 +478,6 @@ def is_upgradable(name):
         i_distro,
         i_distro_release,
     ) = installdb.get_version_and_distro_release(name)
-
-    packagedb = pisi.db.packagedb.PackageDB()
 
     try:
         (


### PR DESCRIPTION
## Summary

is_upgradable() is often called several hundred times over a list comprehension, require it to take precomputed {InstallDB,PackageDB} instead of reinitializing it for every call.

Installing a package w/ updates available:

ncalls  tottime  percall  cumtime  percall filename:lineno(function) Before:
2549    0.012    0.000    0.455    0.000 upgrade.py:478(is_upgradable)
Now:
2549    0.004    0.000    0.119    0.000 upgrade.py:481(is_upgradable)

## Test Plan

Install a few packages, ensure list-upgradable still works as expected.