### PR TITLE
Distinguish between upgrading & installing callbacks

### DIFF
--- a/pisi/atomicoperations.py
+++ b/pisi/atomicoperations.py
@@ -163,12 +163,17 @@ class Install(AtomicOperation):
             _("Installing %s, version %s, release %s")
             % (self.pkginfo.name, self.pkginfo.version, self.pkginfo.release)
         )
-        ctx.ui.notify(pisi.ui.installing, package=self.pkginfo, files=self.files)
 
         self.ask_reinstall = ask_reinstall
+        self.check_operation()
+
+        if self.operation == UPGRADE:
+            ctx.ui.notify(pisi.ui.upgrading, package=self.pkginfo, files=self.files)
+        else:
+            ctx.ui.notify(pisi.ui.installing, package=self.pkginfo, files=self.files)
+
         self.check_versioning(self.pkginfo.version, self.pkginfo.release)
         self.check_relations()
-        self.check_operation()
 
         self.extract_install()
         self.store_pisi_files()

--- a/pisi/ui.py
+++ b/pisi/ui.py
@@ -15,10 +15,11 @@
     downloading,
     packagestogo,
     updatingrepo,
+    upgrading,
     cached,
     desktopfile,
     systemconf,
-) = list(range(14))
+) = list(range(15))
 
 
 class UI(object):


### PR DESCRIPTION
## Summary

Previously, pisi would emit a installing callback regardless if the package was upgrading or newly installing. This caused issues in our packagekit backend which relied on the callbacks to emit proper progress reporting.

With this PR we can cleanup the progress handling in our packagekit backend.

Resolves https://github.com/getsolus/eopkg/issues/179

## Test Plan

Install/upgrade a few packages. In a debugger ensure the right self.operation was set for each.