### PR TITLE
db: cache {Install,Package}DB get_version_and_distro_release() calls

### DIFF
--- a/pisi/db/installdb.py
+++ b/pisi/db/installdb.py
@@ -156,9 +156,13 @@ class InstallDB(lazydb.LazyDB):
         return distro, release
 
     def get_version_and_distro_release(self, package):
+        if package in self.version_cache:
+            return self.version_cache[package]
         metadata_xml = os.path.join(self.package_path(package), ctx.const.metadata_xml)
         meta_doc = iksemel.parse(metadata_xml)
-        return self.__get_version(meta_doc) + self.__get_distro_release(meta_doc)
+        info = self.__get_version(meta_doc) + self.__get_distro_release(meta_doc)
+        self.version_cache[package] = info
+        return info
 
     def get_version(self, package):
         metadata_xml = os.path.join(self.package_path(package), ctx.const.metadata_xml)

--- a/pisi/db/lazydb.py
+++ b/pisi/db/lazydb.py
@@ -43,6 +43,8 @@ class LazyDB(Singleton):
     def __init__(self, cacheable=False, cachedir=None):
         if "initialized" not in self.__dict__:
             self.initialized = False
+        if "version_cache" not in self.__dict__:
+            self.version_cache = {}
         self.cacheable = cacheable
         self.cachedir = cachedir
 

--- a/pisi/db/packagedb.py
+++ b/pisi/db/packagedb.py
@@ -214,10 +214,14 @@ class PackageDB(lazydb.LazyDB):
         return distro, release
 
     def get_version_and_distro_release(self, name, repo):
+        if (name, repo) in self.version_cache:
+            return self.version_cache[(name, repo)]
         if not self.has_package(name, repo):
             raise Error(_("Package %s not found.") % name)
         pkg_doc = iksemel.parseString(self.pdb.get_item(name, repo).decode())
-        return self.__get_version(pkg_doc) + self.__get_distro_release(pkg_doc)
+        info = self.__get_version(pkg_doc) + self.__get_distro_release(pkg_doc)
+        self.version_cache[(name, repo)] = info
+        return info
 
     def get_version(self, name, repo):
         if not self.has_package(name, repo):


### PR DESCRIPTION
## Summary

Build up an internal cache of {Install,Package}DB objects. Due to how frequently often these objects are referenced it ends up providing about a 1.15x to 1.5x speedup than constantly fetching from the pickle cache depending on the context of currently enabled repos, and, up to a 3.2x speedup than reading from the raw xml files incase the pickle cache is not available for any reason.

## Benchmarks

`./eopkg.py3 install openroad` (order: ['cudd', 'readline', 'yosys', 'eqy', 'sby', 'or-tools', 'opensta', 'openroad'])

Baseline (no LZMA_MT): 4.208s
Cached DBs                    : 2.816s
LZMA_MT eopkgs          : 2.850s
Cached DB + LZMA_MT: 1.876s

averaged over 5 runs for each

edit: with `--ignore-safety` and `--ignore-revdeps-of-deps` safety checks passed this only provides a 1.15x speedup

## Test Plan

Still testing