### PR TITLE
Avoid computing list_upgradable() needlessly

### DIFF
--- a/pisi/cli/install.py
+++ b/pisi/cli/install.py
@@ -155,8 +155,9 @@ expanded to package names.
             packages = pisi.blacklist.exclude(packages, ctx.get_option("exclude"))
 
         # See operations.install.plan_install_pkgs
-        if len(pisi.api.list_upgradable()) != 0 and not ctx.get_option(
-            "ignore_revdeps_of_deps_check"
+        if (
+            not ctx.get_option("ignore_revdeps_of_deps_check")
+            and pisi.api.list_upgradable()
         ):
             ctx.ui.warning(
                 _(

--- a/pisi/operations/install.py
+++ b/pisi/operations/install.py
@@ -352,10 +352,8 @@ def plan_install_pkg_names(A):
     installdb = pisi.db.installdb.InstallDB()
 
     # Check if updates are available to opt into the slow path
-    available_updates = list()
-    if len(pisi.api.list_upgradable()) != 0 and not ctx.get_option(
-        "ignore_revdeps_of_deps_check"
-    ):
+    available_updates = []
+    if not ctx.get_option("ignore_revdeps_of_deps_check"):
         available_updates = pisi.api.list_upgradable()
 
     G_f = pgraph.PGraph(packagedb)  # construct G_f


### PR DESCRIPTION
## Summary

This operation is fairly expensive taking about 400ms to run, let's not run it needlessly.

## Test Plan

Run eopkg it foo with and without --ignore-revdeps-of-deps to verify we get about a 400ms speedup for each time the call is avoided.