### PR TITLE
Revert "db: cache {Install,Package}DB get_version_and_distro_release(……) calls"

### DIFF
--- a/pisi/db/installdb.py
+++ b/pisi/db/installdb.py
@@ -156,13 +156,9 @@ class InstallDB(lazydb.LazyDB):
         return distro, release
 
     def get_version_and_distro_release(self, package):
-        if package in self.version_cache:
-            return self.version_cache[package]
         metadata_xml = os.path.join(self.package_path(package), ctx.const.metadata_xml)
         meta_doc = iksemel.parse(metadata_xml)
-        info = self.__get_version(meta_doc) + self.__get_distro_release(meta_doc)
-        self.version_cache[package] = info
-        return info
+        return self.__get_version(meta_doc) + self.__get_distro_release(meta_doc)
 
     def get_version(self, package):
         metadata_xml = os.path.join(self.package_path(package), ctx.const.metadata_xml)

--- a/pisi/db/lazydb.py
+++ b/pisi/db/lazydb.py
@@ -43,8 +43,6 @@ class LazyDB(Singleton):
     def __init__(self, cacheable=False, cachedir=None):
         if "initialized" not in self.__dict__:
             self.initialized = False
-        if "version_cache" not in self.__dict__:
-            self.version_cache = {}
         self.cacheable = cacheable
         self.cachedir = cachedir
 

--- a/pisi/db/packagedb.py
+++ b/pisi/db/packagedb.py
@@ -214,14 +214,10 @@ class PackageDB(lazydb.LazyDB):
         return distro, release
 
     def get_version_and_distro_release(self, name, repo):
-        if (name, repo) in self.version_cache:
-            return self.version_cache[(name, repo)]
         if not self.has_package(name, repo):
             raise Error(_("Package %s not found.") % name)
         pkg_doc = iksemel.parseString(self.pdb.get_item(name, repo).decode())
-        info = self.__get_version(pkg_doc) + self.__get_distro_release(pkg_doc)
-        self.version_cache[(name, repo)] = info
-        return info
+        return self.__get_version(pkg_doc) + self.__get_distro_release(pkg_doc)
 
     def get_version(self, name, repo):
         if not self.has_package(name, repo):


### PR DESCRIPTION
## Summary

This reverts commit 06687480048af003b252c90a0ba2bb72415e5dc3.

Unfortunately things stored in the cache may not get written to the pickle cache correctly which can cause it to become stale

## Test Plan

After upgrading system.base packages, eopkg no longer shows there are still forced system.base packages to install.