### PR TITLE
pxml/autoxml: Replace hacky regex parsing with a list comprehension

### DIFF
--- a/pisi/pxml/autoxml.py
+++ b/pisi/pxml/autoxml.py
@@ -286,19 +286,9 @@ class autoxml(oo.autosuper, oo.autoprop):
         errorss = []
         formatters = []
 
-        # FIXME: What is this? Remove this crap and try to fix autoxml, if can not be fixed then
-        # really throw whole autoxml to junk. But not this.
-
-        # read declaration order from source
-        # code contributed by bahadir kandemir
-        try:
-            fn = re.compile(r"\s*([tas]_[a-zA-Z]+).*").findall
-
-            inspect.linecache.clearcache()
-            lines = list(filter(fn, inspect.getsourcelines(cls)[0]))
-            decl_order = [x.split()[0] for x in lines]
-        except IOError:
-            decl_order = list(dict.keys())
+        decl_order = [
+            name for name in cls.__dict__.keys() if name.startswith(("t_", "a_", "s_"))
+        ]
 
         # there should be at most one str member, and it should be
         # the first to process


### PR DESCRIPTION
## Summary

It's a bit hard to slouth why this code was added, however, it appears
to be to ensure the source code order of the keys was respected. With
PEP 520, this should no longer be an issue, as it ensures class
namespace ordering since Python 3.7.

Additionally, previously, some python source code garbage was finding
it's way in the variable, e.g.

Before:
```
['t_Distribution', 't_Specs', 't_Packages', '#',
't_Components', 't_Groups', 'if', 'obsoletes_list', 'obsoletes_list',
'latest_packages', 'for', 'if', 'latest_packages.append((pkg,', 'if',
'self.packages']
```

Now
```
['t_Distribution', 't_Specs', 't_Packages', 't_Components', 't_Groups']
```

This also provides a nice speedup throughout the codebase, in one case
providing up to a 1.42x speedup from listing the installed files of the
systemd package.

## Test Plan

Run a few eopkg operations, install, remove, info, li, la, lu etc.
Print out decl_order before and after, verifying it was the same except for the garbage python source code inserts now removed