### PR TITLE
Pickle format upgrade (2 -> 4) in FilesDB

### DIFF
--- a/pisi/db/filesdb.py
+++ b/pisi/db/filesdb.py
@@ -4,6 +4,7 @@
 import dbm
 import hashlib
 import os
+import pickle
 import re
 import shelve
 
@@ -22,9 +23,11 @@ from pisi.db import lazydb
 # So currently filesdb is the only db and we cant still get rid of rebuild-db :/
 
 # This MUST match the version used in eopkg.py2 as long as that is in use.
-FILESDB_PICKLE_PROTOCOL_VERSION = 2
+# Now that eopkg.py2 is no longer in use, just use the current default version.
+FILESDB_PICKLE_PROTOCOL_VERSION = pickle.DEFAULT_PROTOCOL
 
 # We suspect that there will be an advantage in versioning this separately
+# As long as a gdbm-backed shelve is used, no need to bump this beyond 4
 FILESDB_FORMAT_VERSION = 4
 
 class FilesDB(lazydb.LazyDB):


### PR DESCRIPTION

## Summary

The goal of this PR is to ensure that the pickle format variable for the filesdb shelve is now
set to upstream `pickle.DEFAULT_PROTOCOL`, such that no refactoring is required for
debugging output.

This makes it upstream's responsibility to ensure pickle format compatibility.

## Test Plan

- Benchmarked this branch against joey's lmdb branch with no issue.
- Joey said he saw a small speedup going from pickle protocol 2 (py2 compatible) to pickle protocol 4 (py3.12 `pickle.DEFAULT_PROTOCOL` value):
<img width="2691" height="183" alt="image" src="https://github.com/user-attachments/assets/6cf0fb68-0c63-4bb2-a380-170bb38ed03a" />

