### PR TITLE
Introduce PackageResource to start to detangle fetching from atomicoperations

### DIFF
--- a/pisi/api.py
+++ b/pisi/api.py
@@ -3,39 +3,39 @@
 
 import fcntl
 import os
-import signal
 import re
-from . import fetcher
-
-from pisi import translate as _
+import signal
 
 import pisi
+import pisi.atomicoperations
+import pisi.blacklist
+import pisi.config
 import pisi.context as ctx
-import pisi.uri
-import pisi.util
-import pisi.pgraph as pgraph
+import pisi.db.componentdb
+import pisi.db.filesdb
+import pisi.db.groupdb
+import pisi.db.historydb
+import pisi.db.installdb
 import pisi.db.packagedb
 import pisi.db.repodb
-import pisi.db.filesdb
-import pisi.db.installdb
-import pisi.db.historydb
-import pisi.db.componentdb
-import pisi.db.groupdb
-import pisi.index
-import pisi.config
-import pisi.metadata
+import pisi.errors
 import pisi.file
-import pisi.blacklist
-import pisi.atomicoperations
+import pisi.index
+import pisi.metadata
+import pisi.operations.build
+import pisi.operations.check
+import pisi.operations.helper
+import pisi.operations.history
+import pisi.operations.install
 import pisi.operations.remove
 import pisi.operations.upgrade
-import pisi.operations.install
-import pisi.operations.history
-import pisi.operations.helper
-import pisi.operations.check
-import pisi.operations.build
+import pisi.pgraph as pgraph
 import pisi.signalhandler as signalhandler
-import pisi.errors
+import pisi.uri
+import pisi.util
+from pisi import translate as _
+
+from . import fetcher
 
 
 def locked(func):
@@ -425,6 +425,7 @@ def fetch(packages=[], path=os.path.curdir, repo=None):
     @param path: path to where the packages will be downloaded. If not given, packages will be downloaded
     to the current working directory.
     """
+
     packagedb = pisi.db.packagedb.PackageDB()
     repodb = pisi.db.repodb.RepoDB()
 
@@ -433,23 +434,17 @@ def fetch(packages=[], path=os.path.curdir, repo=None):
         return
 
     for name in packages:
-        package, repo = packagedb.get_package_repo(name, repo)
-        ctx.ui.info(_(f"{package.name} package found in {repo} repository"))
-        uri = pisi.uri.URI(package.packageURI)
-        output = os.path.join(path, uri.path())
-        if os.path.exists(output) and package.packageHash == pisi.util.sha1_file(
+        resource = packagedb.get_resource(name, repo=repo)
+        ctx.ui.info(_(f"Package {name} found in repository {resource.repo}"))
+
+        output = os.path.join(path, resource.uri.filename())
+        if os.path.exists(output) and resource.expected_hash == pisi.util.sha1_file(
             output
         ):
-            ctx.ui.warning(_("%s package already fetched") % uri.path())
+            ctx.ui.warning(_(f"{resource.uri.filename()} package already fetched"))
             continue
-        if uri.is_absolute_path():
-            url = str(uri)
-        else:
-            url = os.path.join(
-                os.path.dirname(repodb.get_repo_url(repo)), str(uri.path())
-            )
 
-        fetcher.fetch_url(url, path, ctx.ui.Progress)
+        fetcher.fetch_url(resource.uri, path, ctx.ui.Progress)
 
 
 @locked
@@ -472,7 +467,9 @@ def remove(packages, ignore_dependency=False, ignore_safety=False):
     @param ignore_safety: system.base packages can also be removed if True
     """
     pisi.db.historydb.HistoryDB().create_history("remove")
-    return pisi.operations.remove.remove(packages, ignore_dependency, ignore_safety, force_prompt=True)
+    return pisi.operations.remove.remove(
+        packages, ignore_dependency, ignore_safety, force_prompt=True
+    )
 
 
 @locked
@@ -944,6 +941,7 @@ def rebuild_db(files=False):
 
     filesdb = pisi.db.filesdb.FilesDB()
     filesdb.init(force_rebuild=True)
+
 
 ############# FIXME: this was a quick fix. ##############################
 

--- a/pisi/atomicoperations.py
+++ b/pisi/atomicoperations.py
@@ -70,8 +70,8 @@ class Install(AtomicOperation):
         packagedb = pisi.db.packagedb.PackageDB()
         resource = packagedb.get_resource(name)
 
-        ctx.ui.info(_("Package %s found in repository") % name)
-        ctx.ui.info(_("Package URI: %s") % resource.uri, verbose=True)
+        ctx.ui.info(_(f"Package {name} found in repository"))
+        ctx.ui.info(_(f"Package URI: {resource.uri}"), verbose=True)
 
         if resource.uri.is_remote_file():
             if os.path.exists(resource.local_path):

--- a/pisi/atomicoperations.py
+++ b/pisi/atomicoperations.py
@@ -3,24 +3,23 @@
 
 """Atomic package operations such as install/remove/upgrade"""
 
-from pisi import translate as _
-from pisi.path import is_usr_merged_duplicate
-
+import base64
 import os
 import shutil
 import zipfile
 
 import pisi
 import pisi.context as ctx
-import pisi.util as util
-import pisi.metadata
-import pisi.files
-import pisi.uri
-import pisi.ui
-import pisi.version
-import pisi.operations.delta
 import pisi.db
-import base64
+import pisi.files
+import pisi.metadata
+import pisi.operations.delta
+import pisi.ui
+import pisi.uri
+import pisi.util as util
+import pisi.version
+from pisi import translate as _
+from pisi.path import is_usr_merged_duplicate
 
 
 class Error(pisi.Error):
@@ -69,71 +68,31 @@ class Install(AtomicOperation):
     @staticmethod
     def from_name(name, ignore_dep=None):
         packagedb = pisi.db.packagedb.PackageDB()
-        # download package and return an installer object
-        # find package in repository
-        repo = packagedb.which_repo(name)
-        if repo:
-            repodb = pisi.db.repodb.RepoDB()
-            ctx.ui.info(_("Package %s found in repository %s") % (name, repo))
+        resource = packagedb.get_resource(name)
 
-            repo = repodb.get_repo(repo)
-            pkg = packagedb.get_package(name)
-            delta = None
+        ctx.ui.info(_("Package %s found in repository") % name)
+        ctx.ui.info(_("Package URI: %s") % resource.uri, verbose=True)
 
-            installdb = pisi.db.installdb.InstallDB()
-            # Package is installed. This is an upgrade. Check delta.
-            if installdb.has_package(pkg.name):
-                (
-                    version,
-                    release,
-                    build,
-                    distro,
-                    distro_release,
-                ) = installdb.get_version_and_distro_release(pkg.name)
-                if distro_release == pkg.distributionRelease:
-                    delta = pkg.get_delta(release)
-
-            ignore_delta = ctx.config.values.general.ignore_delta
-
-            # If delta exists than use the delta uri.
-            if delta and not ignore_delta:
-                pkg_uri = delta.packageURI
-                pkg_hash = delta.packageHash
+        if resource.uri.is_remote_file():
+            if os.path.exists(resource.local_path):
+                if util.sha1_file(resource.local_path) != resource.expected_hash:
+                    os.unlink(resource.local_path)
             else:
-                pkg_uri = pkg.packageURI
-                pkg_hash = pkg.packageHash
+                # Explicitly download if not cached.
+                # Note: In the future, this should be handled by a separate fetch stage.
+                dest = os.path.dirname(resource.local_path)
+                pisi.file.File.download(resource.uri, dest)
 
-            uri = pisi.uri.URI(pkg_uri)
-            if uri.is_absolute_path():
-                pkg_path = str(pkg_uri)
-            else:
-                pkg_path = os.path.join(
-                    os.path.dirname(repo.indexuri.get_uri()), str(uri.path())
-                )
-
-            ctx.ui.info(_("Package URI: %s") % pkg_path, verbose=True)
-
-            # Bug 4113
-            cached_file = pisi.package.Package.is_cached(pkg_path)
-            if cached_file and util.sha1_file(cached_file) != pkg_hash:
-                os.unlink(cached_file)
-                cached_file = None
-
-            install_op = Install(pkg_path, ignore_dep)
-
-            # Bug 4113
-            if not cached_file:
-                downloaded_file = install_op.package.filepath
-                if pisi.util.sha1_file(downloaded_file) != pkg_hash:
-                    raise pisi.Error(
-                        _(
-                            "Download Error: Package does not match the repository package."
-                        )
-                    )
-
-            return install_op
+            pkg_path = resource.local_path
         else:
-            raise Error(_("Package %s not found in any active repository.") % name)
+            pkg_path = resource.uri.path()
+
+        if util.sha1_file(pkg_path) != resource.expected_hash:
+            raise Error(
+                _("Download Error: Package does not match the repository package.")
+            )
+
+        return Install(pkg_path, ignore_dep)
 
     def __init__(self, package_fname, ignore_dep=None, ignore_file_conflicts=None):
         "initialize from a file name"

--- a/pisi/atomicoperations.py
+++ b/pisi/atomicoperations.py
@@ -81,6 +81,9 @@ class Install(AtomicOperation):
                 # Explicitly download if not cached.
                 # Note: In the future, this should be handled by a separate fetch stage.
                 dest = os.path.dirname(resource.local_path)
+
+                ctx.ui.notify(pisi.ui.downloading, packageresource=resource)
+
                 pisi.file.File.download(resource.uri, dest)
 
             pkg_path = resource.local_path

--- a/pisi/atomicoperations.py
+++ b/pisi/atomicoperations.py
@@ -551,6 +551,14 @@ def install_single(pkg, upgrade=False):
 # FIXME: Here and elsewhere pkg_location must be a URI
 def install_single_file(pkg_location, upgrade=False):
     """install a package file"""
+    url = pisi.uri.URI(pkg_location)
+    if url.is_remote_file():
+        dest = ctx.config.cached_packages_dir()
+        filepath = os.path.join(dest, url.filename())
+        if not os.path.exists(filepath):
+            pisi.file.File.download(url, dest)
+        pkg_location = filepath
+
     Install(pkg_location).install(not upgrade)
 
 

--- a/pisi/db/packagedb.py
+++ b/pisi/db/packagedb.py
@@ -4,21 +4,25 @@
 # installation database
 #
 
+import datetime
+import gettext
+import gzip
+import os
 import re
 import time
-import gzip
-import gettext
-import datetime
 
 import iksemel
 
+import pisi.context
 import pisi.db
-import pisi.metadata
-import pisi.dependency
 import pisi.db.itembyrepo
 import pisi.db.lazydb as lazydb
-from pisi import translate as _
+import pisi.dependency
+import pisi.metadata
+import pisi.package
+import pisi.uri
 from pisi import Error
+from pisi import translate as _
 
 
 class PackageDB(lazydb.LazyDB):
@@ -231,6 +235,57 @@ class PackageDB(lazydb.LazyDB):
         package = pisi.metadata.Package()
         package.parse(pkg)
         return package, repo
+
+    def get_resource(self, name, repo=None):
+        repodb = pisi.db.repodb.RepoDB()
+        installdb = pisi.db.installdb.InstallDB()
+
+        if repo and not repodb.has_repo(repo):
+            raise Error(_(f"Package {name} not found in any active repository."))
+        repo_name = repo or self.which_repo(name)
+
+        repo = repodb.get_repo(repo_name)
+        pkg = self.get_package(name, repo=repo_name)
+        delta = None
+
+        if installdb.has_package(pkg.name):
+            (
+                version,
+                release,
+                build,
+                distro,
+                distro_release,
+            ) = installdb.get_version_and_distro_release(pkg.name)
+            if distro_release == pkg.distributionRelease:
+                delta = pkg.get_delta(release)
+
+        ignore_delta = pisi.context.config.values.general.ignore_delta
+
+        if delta and not ignore_delta:
+            pkg_uri_str = delta.packageURI
+            pkg_hash = delta.packageHash
+            pkg_size = delta.packageSize
+            is_delta = True
+        else:
+            pkg_uri_str = pkg.packageURI
+            pkg_hash = pkg.packageHash
+            pkg_size = pkg.packageSize
+            is_delta = False
+
+        uri = pisi.uri.URI(pkg_uri_str)
+        if not uri.is_absolute_path():
+            pkg_uri_str = os.path.join(
+                os.path.dirname(repo.indexuri.get_uri()), str(uri.path())
+            )
+
+        uri = pisi.uri.URI(pkg_uri_str)
+        local_path = os.path.join(
+            pisi.context.config.cached_packages_dir(), uri.filename()
+        )
+
+        return pisi.package.PackageResource(
+            name, uri, repo_name, pkg_hash, pkg_size, local_path, is_delta
+        )
 
     def which_repo(self, name):
         return self.pdb.which_repo(name)

--- a/pisi/operations/helper.py
+++ b/pisi/operations/helper.py
@@ -4,15 +4,15 @@
 import os
 
 from ordered_set import OrderedSet as set
-from pisi import translate as _
-from pisi import Error
 
 import pisi
-import pisi.context as ctx
-import pisi.util as util
-import pisi.ui as ui
 import pisi.conflict
+import pisi.context as ctx
 import pisi.db
+import pisi.ui as ui
+import pisi.util as util
+from pisi import Error
+from pisi import translate as _
 
 
 def reorder_base_packages_old(order):
@@ -114,50 +114,20 @@ def extract_automatic(A, total):
 
 
 def calculate_download_sizes(order):
-    total_size = cached_size = 0
-
-    installdb = pisi.db.installdb.InstallDB()
     packagedb = pisi.db.packagedb.PackageDB()
+    resources = [packagedb.get_resource(name) for name in order]
 
-    try:
-        cached_packages_dir = ctx.config.cached_packages_dir()
-    except OSError:
-        # happens when cached_packages_dir tried to be created by an unpriviledged user
-        cached_packages_dir = None
-
-    for pkg in [packagedb.get_package(name) for name in order]:
-        delta = None
-        if installdb.has_package(pkg.name):
-            (
-                version,
-                release,
-                build,
-                distro,
-                distro_release,
-            ) = installdb.get_version_and_distro_release(pkg.name)
-            if distro_release == pkg.distributionRelease:
-                delta = pkg.get_delta(release)
-
-        ignore_delta = ctx.config.values.general.ignore_delta
-
-        if delta and not ignore_delta:
-            fn = os.path.basename(delta.packageURI)
-            pkg_hash = delta.packageHash
-            pkg_size = delta.packageSize
-        else:
-            fn = os.path.basename(pkg.packageURI)
-            pkg_hash = pkg.packageHash
-            pkg_size = pkg.packageSize
-
-        if cached_packages_dir:
-            path = util.join_path(cached_packages_dir, fn)
-            # check the file and sha1sum to be sure it _is_ the cached package
-            if os.path.exists(path) and util.sha1_file(path) == pkg_hash:
-                cached_size += pkg_size
-            elif os.path.exists("%s.part" % path):
-                cached_size += os.stat("%s.part" % path).st_size
-
-        total_size += pkg_size
+    total_size = sum(r.size for r in resources)
+    cached_size = 0
+    for r in resources:
+        if os.path.exists(r.local_path):
+            if util.sha1_file(r.local_path) == r.expected_hash:
+                cached_size += r.size
+            else:
+                # partial download?
+                part_path = r.local_path + ".part"
+                if os.path.exists(part_path):
+                    cached_size += os.stat(part_path).st_size
 
     ctx.ui.notify(ui.cached, total=total_size, cached=cached_size)
     return total_size, cached_size

--- a/pisi/operations/install.py
+++ b/pisi/operations/install.py
@@ -201,6 +201,21 @@ def install_pkg_files(package_URIs, reinstall=False):
             ctx.ui.info(util.format_by_columns(sorted(already_installed)))
         package_URIs = tobe_installed
 
+    # Download remote files first
+    local_URIs = []
+    for x in package_URIs:
+        url = pisi.uri.URI(x)
+        if url.is_remote_file():
+            dest = ctx.config.cached_packages_dir()
+            filepath = os.path.join(dest, url.filename())
+            local_URIs.append(filepath)
+            if not os.path.exists(filepath):
+                pisi.file.File.download(url, dest)
+        else:
+            local_URIs.append(x)
+
+    package_URIs = local_URIs
+
     if ctx.config.get_option("ignore_dependency"):
         # simple code path then
         for x in package_URIs:

--- a/pisi/package.py
+++ b/pisi/package.py
@@ -22,6 +22,19 @@ class Error(pisi.Error):
     pass
 
 
+class PackageResource:
+    def __init__(
+        self, name, uri, repo, expected_hash, size, local_path, is_delta=False
+    ):
+        self.name = name
+        self.uri = uri
+        self.repo = repo
+        self.expected_hash = expected_hash
+        self.size = size
+        self.local_path = local_path
+        self.is_delta = is_delta
+
+
 class Package:
     """eopkg Package Class provides access to a pisi package (.pisi
     file)."""

--- a/pisi/package.py
+++ b/pisi/package.py
@@ -64,10 +64,6 @@ class Package:
         self.files = None
         self.repo = None
 
-        url = pisi.uri.URI(packagefn)
-        if url.is_remote_file():
-            self.fetch_remote_file(url)
-
         try:
             self.impl = archive.ArchiveZip(self.filepath, "zip", mode)
         except IOError as e:
@@ -95,34 +91,6 @@ class Package:
             raise Error(_("Unsupported package format: %s") % format)
 
         self.tmp_dir = tmp_dir or ctx.config.tmp_dir()
-
-    def fetch_remote_file(self, url):
-        dest = ctx.config.cached_packages_dir()
-        self.filepath = os.path.join(dest, url.filename())
-
-        # So we can emit a notify event with the package info
-        pkg_name, pkg_version = pisi.util.parse_package_name(url.filename())
-        self.metadata, self.files, self.repo = pisi.api.info_name(pkg_name, False)
-
-        if not os.path.exists(self.filepath):
-            try:
-                ctx.ui.notify(
-                    pisi.ui.downloading, package=self.metadata.package, files=self.files
-                )
-                pisi.file.File.download(url, dest)
-            except pisi.fetcher.FetchError:
-                # Bug 3465
-                if ctx.get_option("reinstall"):
-                    raise Error(
-                        _(
-                            "There was a problem while fetching '%s'.\nThe package "
-                            "may have been upgraded. Please try to upgrade the package."
-                        )
-                        % url
-                    )
-                raise
-        else:
-            ctx.ui.info(_("%s [cached]") % url.filename())
 
     def add_to_package(self, fn, an=None):
         """Add a file or directory to package"""


### PR DESCRIPTION
## Summary

Provide the initial infrastructure which will allow us to detangle package fetching operations from atomicoperations. This in turn will allow us to modernize the fetching code which will allow concurrency, connection pooling and other benefits.

The original pisi developers had the wisdom to separate atomicoperations from install/upgrade operations but, sadly, actual package fetching remained closely tangled. It required passing around half initialized objects in a specific order, in an esoteric way, to get the package to download.

As a way to rectify this, provide a `PackageResource` class, as well as a `get_resource()` method in packagedb to provide the initial detangling from `Install.from_name()` in atomicoperations.

Furthermore, always explicitly download files upfront through `pisi.File.download()` to remove implicit downloading through `pisi.package.Package()` and remove `fetch_remote_item()` from said class.

## Test Plan

eopkg it -c system.devel, eopkg rm -c system.devel, eopkg it random packages, eopkg dc, eopkg ur, eopkg fetch, eopkg up, eopkg it url.eopkg