### PR TITLE
Make AnotherInstanceError and PrivilegeError inherit from pisi.Error

### DIFF
--- a/pisi/errors.py
+++ b/pisi/errors.py
@@ -1,10 +1,11 @@
 # SPDX-FileCopyrightText: 2005-2011 TUBITAK/UEKAE, 2013-2017 Ikey Doherty, Solus Project
 # SPDX-License-Identifier: GPL-2.0-or-later
+import pisi
 
 
-class AnotherInstanceError(Exception):
+class AnotherInstanceError(pisi.Error):
     pass
 
 
-class PrivilegeError(Exception):
+class PrivilegeError(pisi.Error):
     pass


### PR DESCRIPTION
## Summary
This makes the error handling work again for these exceptions.

Part of #232.

## Test Plan
- Try to reproduce #232.
- See that eopkg has regressed here, and it doesn't print that another instance is running.
- Apply this PR.
- Try again.
- See that the old error message is back!
- Assume that PrivilegeError will also just work this way.