### PR TITLE
fetcher: Add support for local filepaths

### DIFF
--- a/pisi/fetcher.py
+++ b/pisi/fetcher.py
@@ -12,16 +12,17 @@ import contextlib
 import os
 import shutil
 import time
-import urllib.request, urllib.error, urllib.parse
+import urllib.error
+import urllib.parse
+import urllib.request
 from urllib.error import URLError
-
-from pisi import translate as _
 
 # pisi modules
 import pisi
-import pisi.util as util
 import pisi.context as ctx
 import pisi.uri
+import pisi.util as util
+from pisi import translate as _
 
 
 class FetchError(pisi.Error):
@@ -128,6 +129,16 @@ class Fetcher:
         if not self.url.filename():
             raise FetchError(_("Filename error"))
 
+        if self.url.is_local_file():
+            source = os.path.normpath(self.url.path())
+            if not os.path.exists(source):
+                raise FetchError(_("File not found: %s") % source)
+
+            if source != self.archive_file:
+                shutil.copy(source, self.archive_file)
+
+            return self.archive_file
+
         if not os.access(self.destdir, os.W_OK):
             raise FetchError(
                 _('Access denied to write to destination directory: "%s"')
@@ -170,9 +181,6 @@ class Fetcher:
                     urllib.request.urlopen(self.url.get_uri(), timeout=15)
                 ) as fp:
                     headers = fp.info()
-
-                    if self.url.is_local_file():
-                        return os.path.normpath(self.url.path())
 
                     if has_range_support:
                         tfp = open(self.partial_file, "ab")


### PR DESCRIPTION
## Summary
This fixes a few instances where eopkg operations would fail on local repository files stating the url was invalid.

- eopkg fetch now works if the eopkg is in a local repository
- eopkg history now works if the takeback eopkg(s) are in a local repository

## Test Plan

eopkg fetch on an eopkg found in a local repository
eopkg history no longer fails if referenced eopkgs are in a local repository