### PR TITLE
cli: Rename options() -> setup_options() to avoid shadowing optparse

### DIFF
--- a/pisi/cli/addrepo.py
+++ b/pisi/cli/addrepo.py
@@ -29,7 +29,7 @@ NB: We support only local files (e.g., /a/b/c) and http:// URIs at the moment
 
     name = ("add-repo", "ar")
 
-    def options(self):
+    def setup_options(self):
         group = optparse.OptionGroup(self.parser, _("add-repo options"))
         group.add_option(
             "--ignore-check",

--- a/pisi/cli/autoremove.py
+++ b/pisi/cli/autoremove.py
@@ -34,7 +34,7 @@ safe to do so.
 
     name = ("autoremove", "rmf")
 
-    def options(self):
+    def setup_options(self):
         group = optparse.OptionGroup(self.parser, _("autoremove options"))
         super(AutoRemove, self).options(group)
         group.add_option(

--- a/pisi/cli/blame.py
+++ b/pisi/cli/blame.py
@@ -25,7 +25,7 @@ Usage: blame <package> ... <package>
 
     name = ("blame", "bl")
 
-    def options(self):
+    def setup_options(self):
         group = optparse.OptionGroup(self.parser, _("blame options"))
         group.add_option(
             "-r",

--- a/pisi/cli/build.py
+++ b/pisi/cli/build.py
@@ -33,7 +33,7 @@ class Build(command.Command, metaclass=command.autocommand):
 
     name = ("build", "bi")
 
-    def options(self):
+    def setup_options(self):
         self.add_steps_options()
         group = optparse.OptionGroup(self.parser, _("build options"))
         self.add_options(group)

--- a/pisi/cli/check.py
+++ b/pisi/cli/check.py
@@ -39,7 +39,7 @@ class Check(command.Command, metaclass=command.autocommand):
 
     name = ("check", None)
 
-    def options(self):
+    def setup_options(self):
         group = optparse.OptionGroup(self.parser, _("check options"))
 
         group.add_option(

--- a/pisi/cli/command.py
+++ b/pisi/cli/command.py
@@ -73,7 +73,7 @@ class Command(object):
             version="%prog " + pisi.__version__,
             formatter=PisiHelpFormatter(),
         )
-        self.options()
+        self.setup_options()
         self.commonopts()
         (self.options, self.args) = self.parser.parse_args(args)
         if self.args:
@@ -148,7 +148,7 @@ class Command(object):
 
         return p
 
-    def options(self):
+    def setup_options(self):
         """This is a fall back function. If the implementer module provides an
         options function it will be called"""
         pass

--- a/pisi/cli/configurepending.py
+++ b/pisi/cli/configurepending.py
@@ -25,7 +25,7 @@ configures those packages.
 
     name = ("configure-pending", "cp")
 
-    def options(self):
+    def setup_options(self):
         group = optparse.OptionGroup(self.parser, _("configure-pending options"))
         super(ConfigurePending, self).options(group)
         self.parser.add_option_group(group)

--- a/pisi/cli/delta.py
+++ b/pisi/cli/delta.py
@@ -31,7 +31,7 @@ class Delta(command.Command, metaclass=command.autocommand):
 
     name = ("delta", "dt")
 
-    def options(self):
+    def setup_options(self):
         group = optparse.OptionGroup(self.parser, _("delta options"))
         self.add_options(group)
         self.parser.add_option_group(group)

--- a/pisi/cli/fetch.py
+++ b/pisi/cli/fetch.py
@@ -28,7 +28,7 @@ Downloads the given pisi packages to working directory
 
     name = ("fetch", "fc")
 
-    def options(self):
+    def setup_options(self):
         group = optparse.OptionGroup(self.parser, _("fetch options"))
         self.add_options(group)
         self.parser.add_option_group(group)

--- a/pisi/cli/history.py
+++ b/pisi/cli/history.py
@@ -43,7 +43,7 @@ Lists previous operations."""
 
     name = ("history", "hs")
 
-    def options(self):
+    def setup_options(self):
         group = optparse.OptionGroup(self.parser, _("history options"))
         self.add_options(group)
         self.parser.add_option_group(group)

--- a/pisi/cli/index.py
+++ b/pisi/cli/index.py
@@ -33,7 +33,7 @@ class Index(command.Command, metaclass=command.autocommand):
 
     name = ("index", "ix")
 
-    def options(self):
+    def setup_options(self):
         group = optparse.OptionGroup(self.parser, _("index options"))
 
         group.add_option(

--- a/pisi/cli/info.py
+++ b/pisi/cli/info.py
@@ -31,7 +31,7 @@ Usage: info <package1> <package2> ... <packagen>
 
     name = ("info", None)
 
-    def options(self):
+    def setup_options(self):
         group = optparse.OptionGroup(self.parser, _("info options"))
         self.add_options(group)
         self.parser.add_option_group(group)

--- a/pisi/cli/install.py
+++ b/pisi/cli/install.py
@@ -31,7 +31,7 @@ expanded to package names.
 
     name = "install", "it"
 
-    def options(self):
+    def setup_options(self):
         group = optparse.OptionGroup(self.parser, _("install options"))
 
         super(Install, self).options(group)

--- a/pisi/cli/listavailable.py
+++ b/pisi/cli/listavailable.py
@@ -31,7 +31,7 @@ all repositories.
 
     name = ("list-available", "la")
 
-    def options(self):
+    def setup_options(self):
         group = optparse.OptionGroup(self.parser, _("list-available options"))
         group.add_option(
             "-l",

--- a/pisi/cli/listcomponents.py
+++ b/pisi/cli/listcomponents.py
@@ -27,7 +27,7 @@ repositories.
 
     name = ("list-components", "lc")
 
-    def options(self):
+    def setup_options(self):
         group = optparse.OptionGroup(self.parser, _("list-components options"))
         group.add_option(
             "-l",

--- a/pisi/cli/listinstalled.py
+++ b/pisi/cli/listinstalled.py
@@ -27,7 +27,7 @@ Usage: list-installed
 
     name = ("list-installed", "li")
 
-    def options(self):
+    def setup_options(self):
         group = optparse.OptionGroup(self.parser, _("list-installed options"))
         group.add_option(
             "-a",

--- a/pisi/cli/listnewest.py
+++ b/pisi/cli/listnewest.py
@@ -30,7 +30,7 @@ packages from all repositories.
 
     name = ("list-newest", "ln")
 
-    def options(self):
+    def setup_options(self):
         group = optparse.OptionGroup(self.parser, _("list-newest options"))
         group.add_option(
             "-s",

--- a/pisi/cli/listupgrades.py
+++ b/pisi/cli/listupgrades.py
@@ -29,7 +29,7 @@ Lists the packages that will be upgraded.
 
     name = ("list-upgrades", "lu")
 
-    def options(self):
+    def setup_options(self):
         group = optparse.OptionGroup(self.parser, _("list-upgrades options"))
         group.add_option(
             "-l",

--- a/pisi/cli/rebuilddb.py
+++ b/pisi/cli/rebuilddb.py
@@ -28,7 +28,7 @@ dirs under /var/lib/eopkg
 
     name = ("rebuild-db", "rdb")
 
-    def options(self):
+    def setup_options(self):
         group = optparse.OptionGroup(self.parser, _("rebuild-db options"))
 
         group.add_option(

--- a/pisi/cli/remove.py
+++ b/pisi/cli/remove.py
@@ -30,7 +30,7 @@ expanded to package names.
 
     name = ("remove", "rm")
 
-    def options(self):
+    def setup_options(self):
         group = optparse.OptionGroup(self.parser, _("remove options"))
         super(Remove, self).options(group)
         group.add_option(

--- a/pisi/cli/removeorphans.py
+++ b/pisi/cli/removeorphans.py
@@ -30,7 +30,7 @@ installed list will be removed.
 
     name = ("remove-orphans", "rmo")
 
-    def options(self):
+    def setup_options(self):
         group = optparse.OptionGroup(self.parser, _("remove-orphans options"))
         super(RemoveOrphans, self).options(group)
         group.add_option(

--- a/pisi/cli/search.py
+++ b/pisi/cli/search.py
@@ -30,7 +30,7 @@ database.
 
     name = ("search", "sr")
 
-    def options(self):
+    def setup_options(self):
         group = optparse.OptionGroup(self.parser, _("search options"))
         group.add_option(
             "-l",

--- a/pisi/cli/searchfile.py
+++ b/pisi/cli/searchfile.py
@@ -25,7 +25,7 @@ Finds the installed package which contains the specified file.
 
     name = ("search-file", "sf")
 
-    def options(self):
+    def setup_options(self):
         group = optparse.OptionGroup(self.parser, _("search-file options"))
         group.add_option(
             "-l",

--- a/pisi/cli/updaterepo.py
+++ b/pisi/cli/updaterepo.py
@@ -28,7 +28,7 @@ If no repository is given, all repositories are updated.
 
     name = ("update-repo", "ur")
 
-    def options(self):
+    def setup_options(self):
         group = optparse.OptionGroup(self.parser, _("update-repo options"))
 
         group.add_option(

--- a/pisi/cli/upgrade.py
+++ b/pisi/cli/upgrade.py
@@ -37,7 +37,7 @@ expanded to package names.
 
     name = ("upgrade", "up")
 
-    def options(self):
+    def setup_options(self):
         group = optparse.OptionGroup(self.parser, _("upgrade options"))
 
         super(Upgrade, self).options(group)


### PR DESCRIPTION
## Summary

Various python LSPs get confused due to the pisi cli shadowing the optparse.options method.

This leads to errors such as `reportAttributeAccessIssue` in basedpyright for example when accessing various arg options in sub commands.

Avoid shadowing optparse to clean up some of the LSP spam.

## Test Plan

Test a few commands, ensure they still work