### PR TITLE
archive: Remove old python 2 .decode("latin-1") hack

### DIFF
--- a/pisi/archive.py
+++ b/pisi/archive.py
@@ -426,7 +426,7 @@ class ArchiveTar(ArchiveBase):
             if self.tar is None:
                 self.tar = tarfile.open(self.file_path, wmode, fileobj=self.fileobj)
 
-        self.tar.add(file_name.decode("latin-1"), arc_name)
+        self.tar.add(file_name, arc_name)
 
     def close(self):
         self.tar.close()


### PR DESCRIPTION
## Summary

tar accepts a str

Old python 2 hack due to lack of full unicode support, we should be able to remove this.

Here be dragons, beware!

See
https://github.com/getsolus/ypkg/pull/70
and
https://github.com/Zaryob/iksemel/pull/4

## Test Plan

Fixes eopkg delta subcommand