### PR TITLE
cli: Print a warning when repo doesn't exist

### DIFF
--- a/pisi/cli/disablerepo.py
+++ b/pisi/cli/disablerepo.py
@@ -5,6 +5,7 @@ from pisi import translate as _
 
 import pisi.cli.command as command
 import pisi.api
+import pisi.context as ctx
 
 
 class DisableRepo(command.Command, metaclass=command.autocommand):
@@ -33,5 +34,10 @@ Disabled repositories are not taken into account in operations
             return
 
         for repo in self.args:
-            if self.repodb.has_repo(repo):
-                pisi.api.set_repo_activity(repo, False)
+            if not self.repodb.has_repo(repo):
+                ctx.ui.warning(
+                    _(f"Repository '{repo}' does not exist. Cannot disable.")
+                )
+                return
+
+            pisi.api.set_repo_activity(repo, False)

--- a/pisi/cli/enablerepo.py
+++ b/pisi/cli/enablerepo.py
@@ -3,8 +3,9 @@
 
 from pisi import translate as _
 
-import pisi.cli.command as command
 import pisi.api
+import pisi.cli.command as command
+import pisi.context as ctx
 
 
 class EnableRepo(command.Command, metaclass=command.autocommand):
@@ -33,5 +34,8 @@ Disabled repositories are not taken into account in operations
             return
 
         for repo in self.args:
-            if self.repodb.has_repo(repo):
-                pisi.api.set_repo_activity(repo, True)
+            if not self.repodb.has_repo(repo):
+                ctx.ui.warning(_(f"Repository '{repo}' does not exist. Cannot enable."))
+                return
+
+            pisi.api.set_repo_activity(repo, True)


### PR DESCRIPTION
## Summary

This creates a better user experience when using these commands and someone typos the name of a configured repository. Right now, nothing is printed and `eopkg` completes successfully. Adding a warning for these commands lets the user know that they should double-check the command they typed. They may go on to run more `eopkg` operations, and wonder why the results might not be what they expected.

Fixes #311 

## Test Plan

<img width="504" height="197" alt="image" src="https://github.com/user-attachments/assets/0bfcb113-cf7e-4f9f-975e-8b4ecafb4e7e" />

