### PR TITLE
util: Switch get_terminal_size to use shutil instead of using ioctl

### DIFF
--- a/pisi/util.py
+++ b/pisi/util.py
@@ -5,21 +5,21 @@
 
 # standard python modules
 
-import os
-import sys
 import fcntl
+import fnmatch
+import hashlib
+import operator
+import os
 import shutil
 import string
 import struct
-import fnmatch
-import hashlib
-import termios
-import operator
 import subprocess
+import sys
+import termios
 import unicodedata
+from functools import reduce
 
 from pisi import translate as _
-from functools import reduce
 
 
 class Singleton(type):
@@ -239,14 +239,8 @@ def run_logged(cmd):
 
 
 def get_terminal_size():
-    try:
-        ret = fcntl.ioctl(sys.stdout.fileno(), termios.TIOCGWINSZ, "1234")
-    except IOError:
-        rows = int(os.environ.get("LINES", 25))
-        cols = int(os.environ.get("COLUMNS", 80))
-        return rows, cols
-
-    return struct.unpack("hh", ret)
+    size = shutil.get_terminal_size(fallback=(80, 25))
+    return size.lines, size.columns
 
 
 def xterm_title(message):


### PR DESCRIPTION
## Summary

With python 3.14, we were getting a buffer overflow due to passing a 4 byte string ("1234") as an argument to TIOCGWINSZ which expects 8 bytes.

Instead let's just switch to the modern python helpers instead of passing ioctl calls manually, no reason not to.

## Test Plan

eopkg info foo no longer crashes on python 3.14