### PR TITLE
Use requests for downloading, rich for progress bars & concurrently download packages

### DIFF
--- a/pisi/api.py
+++ b/pisi/api.py
@@ -437,16 +437,16 @@ def fetch(packages=[], path=os.path.curdir, repo=None):
 
     for name in packages:
         resource = packagedb.get_resource(name, repo=repo)
+        resource.local_path = os.path.join(path, resource.uri.filename())
         ctx.ui.info(_(f"Package {name} found in repository {resource.repo}"))
 
-        output = os.path.join(path, resource.uri.filename())
-        if os.path.exists(output) and resource.expected_hash == pisi.util.sha1_file(
-            output
-        ):
+        if os.path.exists(
+            resource.local_path
+        ) and resource.expected_hash == pisi.util.sha1_file(resource.local_path):
             ctx.ui.warning(_(f"{resource.uri.filename()} package already fetched"))
             continue
 
-        fetch_items.append((resource.uri, path))
+        fetch_items.append(resource)
 
     # TODO(Evan): Error handling
     if fetch_items:

--- a/pisi/api.py
+++ b/pisi/api.py
@@ -20,9 +20,7 @@ import pisi.db.packagedb
 import pisi.db.repodb
 import pisi.errors
 import pisi.file
-import pisi.index
 import pisi.metadata
-import pisi.operations.build
 import pisi.operations.check
 import pisi.operations.helper
 import pisi.operations.history
@@ -825,7 +823,10 @@ def info_name(package_name, useinstalldb=False, repo=None):
 
 def index(dirs=None, output="eopkg-index.xml", skip_signing=False, compression=0):
     """Accumulate eopkg XML files in a directory, and write an index."""
-    index = pisi.index.Index()
+
+    from pisi.index import Index
+
+    index = Index()
     index.distribution = None
     if not dirs:
         dirs = ["."]
@@ -898,6 +899,8 @@ def update_repo(repo, force=False):
 
 
 def __update_repo(repo, force=False):
+    from pisi.index import Index
+
     signal_handler = signalhandler.SignalHandler()
 
     ctx.ui.action(_("Updating repository: %s") % repo)
@@ -906,7 +909,7 @@ def __update_repo(repo, force=False):
     signal_handler.disable_signal(signal.SIGINT)
 
     repodb = pisi.db.repodb.RepoDB()
-    index = pisi.index.Index()
+    index = Index()
     if repodb.has_repo(repo):
         repouri = repodb.get_repo(repo).indexuri.get_uri()
         try:
@@ -970,7 +973,9 @@ def reorder_base_packages(*args, **kw):
 
 
 def build_until(*args, **kw):
-    return pisi.operations.build.build_until(*args, **kw)
+    from pisi.operations.build import build_until
+
+    return build_until(*args, **kw)
 
 
 def build(*args, **kw):

--- a/pisi/api.py
+++ b/pisi/api.py
@@ -34,8 +34,7 @@ import pisi.signalhandler as signalhandler
 import pisi.uri
 import pisi.util
 from pisi import translate as _
-
-from . import fetcher
+from pisi.fetcher import Fetcher
 
 
 def locked(func):
@@ -428,6 +427,7 @@ def fetch(packages=[], path=os.path.curdir, repo=None):
 
     packagedb = pisi.db.packagedb.PackageDB()
     repodb = pisi.db.repodb.RepoDB()
+    fetcher = Fetcher()
 
     if repo and not repodb.has_repo(repo):
         ctx.ui.error(_(f"Unable to resolve repository: {repo}"))
@@ -444,7 +444,8 @@ def fetch(packages=[], path=os.path.curdir, repo=None):
             ctx.ui.warning(_(f"{resource.uri.filename()} package already fetched"))
             continue
 
-        fetcher.fetch_url(resource.uri, path, ctx.ui.Progress)
+        # TODO(Evan): Error handling
+        fetcher.fetch(resource.uri, path)
 
 
 @locked

--- a/pisi/api.py
+++ b/pisi/api.py
@@ -448,7 +448,6 @@ def fetch(packages=[], path=os.path.curdir, repo=None):
 
         fetch_items.append(resource)
 
-    # TODO(Evan): Error handling
     if fetch_items:
         fetcher.fetch_multi(fetch_items)
 

--- a/pisi/api.py
+++ b/pisi/api.py
@@ -34,7 +34,6 @@ import pisi.signalhandler as signalhandler
 import pisi.uri
 import pisi.util
 from pisi import translate as _
-from pisi.fetcher import Fetcher
 
 
 def locked(func):
@@ -424,6 +423,8 @@ def fetch(packages=[], path=os.path.curdir, repo=None):
     @param path: path to where the packages will be downloaded. If not given, packages will be downloaded
     to the current working directory.
     """
+
+    from pisi.fetcher import Fetcher
 
     packagedb = pisi.db.packagedb.PackageDB()
     repodb = pisi.db.repodb.RepoDB()

--- a/pisi/api.py
+++ b/pisi/api.py
@@ -433,6 +433,8 @@ def fetch(packages=[], path=os.path.curdir, repo=None):
         ctx.ui.error(_(f"Unable to resolve repository: {repo}"))
         return
 
+    fetch_items = []
+
     for name in packages:
         resource = packagedb.get_resource(name, repo=repo)
         ctx.ui.info(_(f"Package {name} found in repository {resource.repo}"))
@@ -444,8 +446,11 @@ def fetch(packages=[], path=os.path.curdir, repo=None):
             ctx.ui.warning(_(f"{resource.uri.filename()} package already fetched"))
             continue
 
-        # TODO(Evan): Error handling
-        fetcher.fetch(resource.uri, path)
+        fetch_items.append((resource.uri, path))
+
+    # TODO(Evan): Error handling
+    if fetch_items:
+        fetcher.fetch_multi(fetch_items)
 
 
 @locked

--- a/pisi/atomicoperations.py
+++ b/pisi/atomicoperations.py
@@ -205,7 +205,9 @@ class Install(AtomicOperation):
             # determine if same distribution release
             if pkg.release == irelease_s:
                 if self.ask_reinstall:
-                    if not ctx.ui.confirm(_("Re-install same distribution release of package?")):
+                    if not ctx.ui.confirm(
+                        _("Re-install same distribution release of package?")
+                    ):
                         raise Error(_("Package re-install declined"))
                 self.operation = REINSTALL
             else:
@@ -560,9 +562,7 @@ class Remove(AtomicOperation):
         ctx.ui.status(_("Removing package %s") % self.package_name)
         ctx.ui.notify(pisi.ui.removing, package=self.package, files=self.files)
         if not self.installdb.has_package(self.package_name):
-            raise Error(
-                _("Trying to remove nonexistent package ") + self.package_name
-            )
+            raise Error(_("Trying to remove nonexistent package ") + self.package_name)
 
         self.check_dependencies()
 
@@ -676,6 +676,6 @@ def remove_single(package_name):
 
 def build(package):
     # wrapper for build op
-    import pisi.operations.build
+    from pisi.operations.build import build
 
-    return pisi.operations.build.build(package)
+    return build(package)

--- a/pisi/atomicoperations.py
+++ b/pisi/atomicoperations.py
@@ -65,39 +65,6 @@ class Install(AtomicOperation):
     # Is this an automatic install?
     automatic = False
 
-    @staticmethod
-    def from_name(name, ignore_dep=None):
-        packagedb = pisi.db.packagedb.PackageDB()
-        resource = packagedb.get_resource(name)
-
-        ctx.ui.info(_(f"Package {name} found in repository {resource.repo}"))
-        ctx.ui.info(_(f"Package URI: {resource.uri}"), verbose=True)
-
-        if resource.uri.is_remote_file():
-            if os.path.exists(resource.local_path):
-                if util.sha1_file(resource.local_path) != resource.expected_hash:
-                    os.unlink(resource.local_path)
-                ctx.ui.info(_(f"{resource.uri.filename()} [cached]"))
-            else:
-                # Explicitly download if not cached.
-                # Note: In the future, this should be handled by a separate fetch stage.
-                dest = os.path.dirname(resource.local_path)
-
-                ctx.ui.notify(pisi.ui.downloading, packageresource=resource)
-
-                pisi.file.File.download(resource.uri, dest)
-
-            pkg_path = resource.local_path
-        else:
-            pkg_path = resource.uri.path()
-
-        if util.sha1_file(pkg_path) != resource.expected_hash:
-            raise Error(
-                _("Download Error: Package does not match the repository package.")
-            )
-
-        return Install(pkg_path, ignore_dep)
-
     def __init__(self, package_fname, ignore_dep=None, ignore_file_conflicts=None):
         "initialize from a file name"
         super(Install, self).__init__(ignore_dep)

--- a/pisi/cli/command.py
+++ b/pisi/cli/command.py
@@ -103,8 +103,12 @@ class Command(object):
         )
         # Username and password are leftovers from auth-basic support.
         # These are here (but hidden) so we can issue a deprecation warning.
-        group.add_option("-u", "--username", action="store", help=optparse.SUPPRESS_HELP)
-        group.add_option("-p", "--password", action="store", help=optparse.SUPPRESS_HELP)
+        group.add_option(
+            "-u", "--username", action="store", help=optparse.SUPPRESS_HELP
+        )
+        group.add_option(
+            "-p", "--password", action="store", help=optparse.SUPPRESS_HELP
+        )
         group.add_option(
             "-L",
             "--bandwidth-limit",
@@ -120,6 +124,13 @@ class Command(object):
             help=_(
                 "Set the max number of retry attempts in case of connection timeouts"
             ),
+        )
+        group.add_option(
+            "-w",
+            "--download-workers",
+            action="store",
+            default=8,
+            help=_("Set the max number of concurrent download workers"),
         )
         group.add_option(
             "-v",

--- a/pisi/cli/info.py
+++ b/pisi/cli/info.py
@@ -3,13 +3,16 @@
 
 import optparse
 
-from pisi import translate as _
-
+import pisi.api
 import pisi.cli.command as command
 import pisi.context as ctx
 import pisi.util as util
-import pisi.api
-import pisi.db
+from pisi import translate as _
+from pisi.db.componentdb import ComponentDB
+from pisi.db.installdb import InstallDB
+from pisi.db.packagedb import PackageDB
+from pisi.db.repodb import RepoDB
+from pisi.index import Index
 
 
 class Info(command.Command, metaclass=command.autocommand):
@@ -24,10 +27,10 @@ Usage: info <package1> <package2> ... <packagen>
 
     def __init__(self, args):
         super(Info, self).__init__(args)
-        self.installdb = pisi.db.installdb.InstallDB()
-        self.componentdb = pisi.db.componentdb.ComponentDB()
-        self.packagedb = pisi.db.packagedb.PackageDB()
-        self.repodb = pisi.db.repodb.RepoDB()
+        self.installdb = InstallDB()
+        self.componentdb = ComponentDB()
+        self.packagedb = PackageDB()
+        self.repodb = RepoDB()
 
     name = ("info", None)
 
@@ -70,7 +73,7 @@ Usage: info <package1> <package2> ... <packagen>
             "--repo",
             action="store",
             default=None,
-            help=_("Resolve package against specified repository")
+            help=_("Resolve package against specified repository"),
         )
         group.add_option(
             "-s",
@@ -95,7 +98,7 @@ Usage: info <package1> <package2> ... <packagen>
             self.help()
             return
 
-        index = pisi.index.Index()
+        index = Index()
         index.distribution = None
 
         # info of components

--- a/pisi/configfile.py
+++ b/pisi/configfile.py
@@ -26,6 +26,7 @@
 # generateDebug = False
 # enableSandbox = False
 # jobs = "-j3"
+# download_workers = "8"
 # CFLAGS= -mtune=generic -march=i686 -O2 -pipe -fomit-frame-pointer -fstack-protector -D_FORTIFY_SOURCE=2
 # CXXFLAGS= -mtune=generic -march=i686 -O2 -pipe -fomit-frame-pointer -fstack-protector -D_FORTIFY_SOURCE=2
 # LDFLAGS= -Wl,-O1 -Wl,-z,relro -Wl,--hash-style=gnu -Wl,--as-needed -Wl,--sort-common
@@ -47,14 +48,13 @@
 # kde_dir = /usr/kde/4
 # qt_dir = /usr/qt/4
 
+import configparser
+import io
 import os
 import re
-import io
-import configparser
-
-from pisi import translate as _
 
 import pisi
+from pisi import translate as _
 
 
 class Error(pisi.Error):
@@ -79,6 +79,7 @@ class GeneralDefaults:
     retry_attempts = 5
     ignore_safety = False
     ignore_delta = False
+    download_workers = 8
 
 
 class BuildDefaults:

--- a/pisi/fetcher.py
+++ b/pisi/fetcher.py
@@ -3,16 +3,15 @@
 
 import os
 import time
+from concurrent.futures import ThreadPoolExecutor
 
 import requests
 from requests import HTTPError
 from requests.adapters import HTTPAdapter
-
 from tqdm import tqdm
 
 import pisi
 import pisi.context as ctx
-
 from pisi import translate as _
 from pisi.uri import URI
 
@@ -48,12 +47,15 @@ class Fetcher:
         proxies = self._get_proxies()
         self.session.proxies.update(proxies)
 
-    def download_file(self, url: str, destination: str) -> None:
+    def download_file(
+        self, url: str, destination: str, progress_bar_pos: int = 0
+    ) -> None:
         """
         Download a remote resource to a local file.
 
         :param str url: The URL of the resource to download.
         :param str destination: The destination file to download to.
+        :param int progress_bar_pos: The position of the progress bar.
         """
         with self.session.get(url.get_uri(), stream=True, timeout=15) as resp:
             resp.raise_for_status()
@@ -69,6 +71,7 @@ class Fetcher:
                     unit="iB",
                     unit_scale=True,
                     unit_divisor=1024,
+                    position=progress_bar_pos,
                 ) as bar,
             ):
                 for chunk in resp.iter_content(chunk_size=MAX_CHUNK_SIZE):
@@ -90,7 +93,13 @@ class Fetcher:
                         if elapsed < expected_time:
                             time.sleep(expected_time - elapsed)
 
-    def fetch(self, url: URI | str, dest_dir: str, filename: str = None) -> None:
+    def fetch(
+        self,
+        url: URI | str,
+        dest_dir: str,
+        filename: str | None,
+        progress_bar_pos: int = 0,
+    ) -> None:
         """
         Fetches a remote resource.
 
@@ -99,6 +108,7 @@ class Fetcher:
         :param str dest_dir: The directory to save the downloaded file to.
         :param filename: The name of the file to use.
         :type filename: str | None
+        :param int progress_bar_pos: The position of the progress bar.
         """
         # This is silly and I hate it.
         if type(url) is str:
@@ -116,9 +126,44 @@ class Fetcher:
             raise IOError(_(f"Unable to access destination file '{archive_file}'"))
 
         try:
-            self.download_file(url, archive_file)
+            self.download_file(url, archive_file, progress_bar_pos)
         except HTTPError:
             raise
+
+    def fetch_multi(self, items: list) -> None:
+        """
+        Fetches multiple remote resources concurrently.
+
+        :param items: A list of (url, dest_dir, filename) tuples.
+        """
+
+        # TODO(Joey): Add a seperate config value for this
+        max_workers = pisi.util.parse_jobs(ctx.config.values.build.jobs)
+        if max_workers == 0:
+            max_workers = 8
+        # Cap the number of concurrent downloads to 8 to avoid overloading
+        if max_workers > 8:
+            max_workers = 8
+
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = []
+
+            for i, item in enumerate(items):
+                url, dest_dir, *rest = item
+                filename = rest[0] if rest else None
+
+                futures.append(
+                    executor.submit(
+                        self.fetch, url, dest_dir, filename, i % max_workers
+                    )
+                )
+
+            for future in futures:
+                try:
+                    future.result()
+                except Exception as e:
+                    ctx.ui.error(str(e))
+                    raise
 
     def _get_bandwidth_limit(self) -> int:
         bandwidth_limit = (

--- a/pisi/fetcher.py
+++ b/pisi/fetcher.py
@@ -61,7 +61,7 @@ class Fetcher:
             resp.raise_for_status()
             start_time = time.time()
 
-            total = int(resp.headers.get("Content-Length"), 0)
+            total = int(resp.headers.get("Content-Length") or 0)
 
             with (
                 open(destination, "wb") as f,

--- a/pisi/fetcher.py
+++ b/pisi/fetcher.py
@@ -8,7 +8,15 @@ from concurrent.futures import ThreadPoolExecutor
 import requests
 from requests import HTTPError
 from requests.adapters import HTTPAdapter
-from tqdm import tqdm
+from rich.progress import (
+    BarColumn,
+    DownloadColumn,
+    Progress,
+    TaskID,
+    TextColumn,
+    TimeRemainingColumn,
+    TransferSpeedColumn,
+)
 
 import pisi
 import pisi.context as ctx
@@ -49,14 +57,19 @@ class Fetcher:
         self.session.proxies.update(proxies)
 
     def download_file(
-        self, url: str, destination: str, progress_bar_pos: int = 0
+        self,
+        url: str,
+        destination: str,
+        progress: Progress | None = None,
+        task_id: TaskID | None = None,
     ) -> None:
         """
         Download a remote resource to a local file.
 
         :param str url: The URL of the resource to download.
         :param str destination: The destination file to download to.
-        :param int progress_bar_pos: The position of the progress bar.
+        :param Progress progress: The rich Progress object to use.
+        :param TaskID task_id: The rich TaskID to use.
         """
         with self.session.get(url.get_uri(), stream=True, timeout=15) as resp:
             resp.raise_for_status()
@@ -64,35 +77,51 @@ class Fetcher:
 
             total = int(resp.headers.get("Content-Length") or 0)
 
-            with (
-                open(destination, "wb") as f,
-                tqdm(
-                    desc=os.path.basename(destination),
-                    total=total,
-                    unit="iB",
-                    unit_scale=True,
-                    unit_divisor=1024,
-                    position=progress_bar_pos,
-                ) as bar,
-            ):
-                for chunk in resp.iter_content(chunk_size=MAX_CHUNK_SIZE):
-                    if not chunk:
-                        # TODO(Evan): Figure out what to do here
-                        break
+            if progress is not None and task_id is not None:
+                progress.update(task_id, total=total)
+                progress.start_task(task_id)
+                self._download_to_file(resp, destination, start_time, progress, task_id)
+            else:
+                with Progress(
+                    TextColumn("[bold blue]{task.description}", justify="right"),
+                    BarColumn(bar_width=None),
+                    "[progress.percentage]{task.percentage:>3.1f}%",
+                    "•",
+                    DownloadColumn(),
+                    "•",
+                    TransferSpeedColumn(),
+                    "•",
+                    TimeRemainingColumn(),
+                ) as p:
+                    tid = p.add_task(os.path.basename(destination), total=total)
+                    self._download_to_file(resp, destination, start_time, p, tid)
 
-                    size = f.write(chunk)
-                    bar.update(size)
+    def _download_to_file(
+        self,
+        resp: requests.Response,
+        destination: str,
+        start_time: float,
+        progress: Progress,
+        task_id: TaskID,
+    ) -> None:
+        with open(destination, "wb") as f:
+            for chunk in resp.iter_content(chunk_size=MAX_CHUNK_SIZE):
+                if not chunk:
+                    break
 
-                    # Handle bandwidth limiting, if set
-                    if self.bandwidth_limit:
-                        elapsed = time.time() - start_time
-                        # Calculate the time this chunk "should" take to stay
-                        # under the limit
-                        expected_time = MAX_CHUNK_SIZE / self.bandwidth_limit
+                size = f.write(chunk)
+                progress.update(task_id, advance=size)
 
-                        # Sleep the difference
-                        if elapsed < expected_time:
-                            time.sleep(expected_time - elapsed)
+                # Handle bandwidth limiting, if set
+                if self.bandwidth_limit:
+                    elapsed = time.time() - start_time
+                    # Calculate the time this chunk "should" take to stay
+                    # under the limit
+                    expected_time = MAX_CHUNK_SIZE / self.bandwidth_limit
+
+                    # Sleep the difference
+                    if elapsed < expected_time:
+                        time.sleep(expected_time - elapsed)
 
                         start_time = time.time()
 
@@ -100,8 +129,9 @@ class Fetcher:
         self,
         url: URI | str,
         dest_dir: str,
-        filename: str | None,
-        progress_bar_pos: int = 0,
+        filename: str | None = None,
+        progress: Progress | None = None,
+        task_id: TaskID | None = None,
     ) -> None:
         """
         Fetches a remote resource.
@@ -111,7 +141,8 @@ class Fetcher:
         :param str dest_dir: The directory to save the downloaded file to.
         :param filename: The name of the file to use.
         :type filename: str | None
-        :param int progress_bar_pos: The position of the progress bar.
+        :param Progress progress: The rich Progress object to use.
+        :param TaskID task_id: The rich TaskID to use.
         """
         # This is silly and I hate it.
         if type(url) is str:
@@ -129,7 +160,7 @@ class Fetcher:
             raise IOError(_(f"Unable to access destination file '{archive_file}'"))
 
         try:
-            self.download_file(url, archive_file, progress_bar_pos)
+            self.download_file(url, archive_file, progress, task_id)
         except HTTPError:
             raise
 
@@ -148,25 +179,46 @@ class Fetcher:
         if max_workers > 8:
             max_workers = 8
 
-        with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            futures = []
+        with Progress(
+            TextColumn("[bold blue]{task.description}", justify="right"),
+            BarColumn(bar_width=None),
+            "[progress.percentage]{task.percentage:>3.1f}%",
+            "•",
+            DownloadColumn(),
+            "•",
+            TransferSpeedColumn(),
+            "•",
+            TimeRemainingColumn(),
+        ) as progress:
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                futures = []
 
-            for i, item in enumerate(items):
-                url, dest_dir, *rest = item
-                filename = rest[0] if rest else None
+                for i, item in enumerate(items):
+                    url, dest_dir, *rest = item
+                    filename = rest[0] if rest else None
 
-                futures.append(
-                    executor.submit(
-                        self.fetch, url, dest_dir, filename, i % max_workers
+                    # This is silly and I hate it.
+                    if type(url) is str:
+                        u = URI(url)
+                    else:
+                        u = url
+
+                    task_id = progress.add_task(
+                        filename or u.filename(), total=None, start=False
                     )
-                )
 
-            for future in futures:
-                try:
-                    future.result()
-                except Exception as e:
-                    ctx.ui.error(str(e))
-                    raise
+                    futures.append(
+                        executor.submit(
+                            self.fetch, url, dest_dir, filename, progress, task_id
+                        )
+                    )
+
+                for future in futures:
+                    try:
+                        future.result()
+                    except Exception as e:
+                        ctx.ui.error(str(e))
+                        raise
 
     def _get_bandwidth_limit(self) -> int:
         bandwidth_limit = (

--- a/pisi/fetcher.py
+++ b/pisi/fetcher.py
@@ -107,7 +107,10 @@ class Fetcher:
                     finally:
                         progress.remove_task(task_id)
                         progress.console.print(
-                            _(f"Copied {os.path.basename(destination)}")
+                            _(
+                                f"[bold yellow]Copied[reset] {os.path.basename(destination)}"
+                            ),
+                            highlight=False,
                         )
                 else:
                     with rich_progress as p:
@@ -135,7 +138,10 @@ class Fetcher:
                     finally:
                         progress.remove_task(task_id)
                         progress.console.print(
-                            _(f"Downloaded {os.path.basename(destination)}")
+                            _(
+                                f"[bold yellow]Downloaded[reset] {os.path.basename(destination)}"
+                            ),
+                            highlight=False,
                         )
                 else:
                     with rich_progress as p:
@@ -149,7 +155,10 @@ class Fetcher:
                         finally:
                             p.remove_task(tid)
                             p.console.print(
-                                _(f"Downloaded {os.path.basename(destination)}")
+                                _(
+                                    f"[bold yellow]Downloaded[reset] {os.path.basename(destination)}"
+                                ),
+                                highlight=False,
                             )
         finally:
             ctx.sig.enable_signal(signal.SIGINT)

--- a/pisi/fetcher.py
+++ b/pisi/fetcher.py
@@ -171,13 +171,13 @@ class Fetcher:
         :param items: A list of (url, dest_dir, filename) tuples.
         """
 
-        # TODO(Joey): Add a seperate config value for this
-        max_workers = pisi.util.parse_jobs(ctx.config.values.build.jobs)
-        if max_workers == 0:
-            max_workers = 8
-        # Cap the number of concurrent downloads to 8 to avoid overloading
-        if max_workers > 8:
-            max_workers = 8
+        max_workers = int(
+            ctx.config.options.download_workers
+            or ctx.config.values.general.download_workers
+        )
+        # Ensure we've got something reasonable to work with
+        max_workers = max(1, min(max_workers, 64))
+        ctx.ui.debug(_(f"Setting {max_workers} concurrent download workers"))
 
         with Progress(
             TextColumn("[bold blue]{task.description}", justify="right"),

--- a/pisi/fetcher.py
+++ b/pisi/fetcher.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 import os
-import shutil
 import signal
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -10,15 +9,19 @@ from concurrent.futures import ThreadPoolExecutor
 import requests
 from requests import HTTPError
 from requests.adapters import HTTPAdapter
+from rich.console import Group
+from rich.live import Live
 from rich.progress import (
     BarColumn,
     DownloadColumn,
     Progress,
     TaskID,
+    TaskProgressColumn,
     TextColumn,
     TimeRemainingColumn,
     TransferSpeedColumn,
 )
+from rich.rule import Rule
 
 import pisi
 import pisi.context as ctx
@@ -28,18 +31,6 @@ from pisi.util import human_readable_rate
 
 """Maximum size in bytes of a download chunk to process at a time."""
 MAX_CHUNK_SIZE = 8192
-
-rich_progress = Progress(
-    TextColumn("[bold blue]{task.description}", justify="right"),
-    BarColumn(bar_width=None),
-    "[progress.percentage]{task.percentage:>3.1f}%",
-    "•",
-    DownloadColumn(),
-    "•",
-    TransferSpeedColumn(),
-    "•",
-    TimeRemainingColumn(),
-)
 
 
 class Fetcher:
@@ -70,11 +61,47 @@ class Fetcher:
         proxies = self._get_proxies()
         self.session.proxies.update(proxies)
 
+        self.progress = Progress(
+            TextColumn("[bold blue]{task.description}", justify="right"),
+            BarColumn(bar_width=None),
+            TaskProgressColumn(),
+            "•",
+            DownloadColumn(),
+            "•",
+            TransferSpeedColumn(),
+            "•",
+            TimeRemainingColumn(),
+        )
+
+        self.overall_progress = Progress(
+            TextColumn("[bold green]Downloading", justify="right"),
+            BarColumn(
+                complete_style="green",
+                bar_width=None,
+            ),
+            TaskProgressColumn(),
+            "•",
+            DownloadColumn(),
+            "•",
+            TransferSpeedColumn(),
+            "•",
+            TimeRemainingColumn(),
+        )
+        self.overall_task = None
+
+        self.live = Live(
+            Group(
+                self.progress,
+                Rule(style="dim"),
+                self.overall_progress,
+            ),
+            refresh_per_second=10,
+        )
+
     def download_file(
         self,
         url: URI,
         destination: str,
-        progress: Progress | None = None,
         description: str | None = None,
     ) -> None:
         """
@@ -82,7 +109,6 @@ class Fetcher:
 
         :param URI url: The URI of the resource to download.
         :param str destination: The destination file to download to.
-        :param Progress progress: The rich Progress object to use.
         :param str description: The description for the task.
         """
         ctx.sig.catch_signal(signal.SIGINT)
@@ -97,69 +123,49 @@ class Fetcher:
 
                 total = os.path.getsize(source)
 
-                if progress is not None:
-                    task_id = progress.add_task(
-                        description or os.path.basename(destination),
-                        total=total,
+                task_id = self.progress.add_task(
+                    description or os.path.basename(destination),
+                    total=total,
+                )
+                try:
+                    self._copy_to_file(
+                        source,
+                        destination,
+                        task_id,
                     )
-                    try:
-                        self._copy_to_file(source, destination, progress, task_id)
-                    finally:
-                        progress.remove_task(task_id)
-                        progress.console.print(
-                            _(
-                                f"[bold yellow]Copied[reset] {os.path.basename(destination)}"
-                            ),
-                            highlight=False,
-                        )
-                else:
-                    with rich_progress as p:
-                        tid = p.add_task(
-                            description or os.path.basename(destination), total=total
-                        )
-                        self._copy_to_file(source, destination, p, tid)
-                return
+                finally:
+                    self.progress.remove_task(task_id)
+                    self.progress.console.print(
+                        _(
+                            f"[bold yellow]Copied[reset] {os.path.basename(destination)}"
+                        ),
+                        highlight=False,
+                    )
 
             with self.session.get(url.get_uri(), stream=True, timeout=15) as resp:
                 resp.raise_for_status()
                 start_time = time.time()
 
                 total = int(resp.headers.get("Content-Length") or 0)
-
-                if progress is not None:
-                    task_id = progress.add_task(
-                        description or os.path.basename(destination),
-                        total=total,
+                task_id = self.progress.add_task(
+                    description or os.path.basename(destination),
+                    total=total,
+                )
+                try:
+                    self._download_to_file(
+                        resp,
+                        destination,
+                        start_time,
+                        task_id,
                     )
-                    try:
-                        self._download_to_file(
-                            resp, destination, start_time, progress, task_id
-                        )
-                    finally:
-                        progress.remove_task(task_id)
-                        progress.console.print(
-                            _(
-                                f"[bold yellow]Downloaded[reset] {os.path.basename(destination)}"
-                            ),
-                            highlight=False,
-                        )
-                else:
-                    with rich_progress as p:
-                        tid = p.add_task(
-                            description or os.path.basename(destination), total=total
-                        )
-                        try:
-                            self._download_to_file(
-                                resp, destination, start_time, p, tid
-                            )
-                        finally:
-                            p.remove_task(tid)
-                            p.console.print(
-                                _(
-                                    f"[bold yellow]Downloaded[reset] {os.path.basename(destination)}"
-                                ),
-                                highlight=False,
-                            )
+                finally:
+                    self.progress.remove_task(task_id)
+                    self.progress.console.print(
+                        _(
+                            f"[bold yellow]Downloaded[reset] {os.path.basename(destination)}"
+                        ),
+                        highlight=False,
+                    )
         finally:
             ctx.sig.enable_signal(signal.SIGINT)
 
@@ -169,7 +175,6 @@ class Fetcher:
         self,
         source: str,
         destination: str,
-        progress: Progress,
         task_id: TaskID,
     ) -> None:
         # Try hardlinking first
@@ -177,22 +182,32 @@ class Fetcher:
             if os.path.exists(destination):
                 os.unlink(destination)
             os.link(source, destination)
-            progress.update(task_id, completed=os.path.getsize(source))
+            size = os.path.getsize(source)
+            self.progress.update(task_id, completed=size)
+            if self.overall_task is not None:
+                self.overall_progress.update(self.overall_task, advance=size)
             return
         except OSError:
             # Fallback to manual copy with progress
             pass
 
-        with progress.open(source, "rb", task_id=task_id) as src:
+        with open(source, "rb") as src:
             with open(destination, "wb") as dst:
-                shutil.copyfileobj(src, dst)
+                while True:
+                    chunk = src.read(MAX_CHUNK_SIZE)
+                    if not chunk:
+                        break
+                    dst.write(chunk)
+                    size = len(chunk)
+                    self.progress.update(task_id, advance=size)
+                    if self.overall_task is not None:
+                        self.overall_progress.update(self.overall_task, advance=size)
 
     def _download_to_file(
         self,
         resp: requests.Response,
         destination: str,
         start_time: float,
-        progress: Progress,
         task_id: TaskID,
     ) -> None:
         with open(destination, "wb") as f:
@@ -201,7 +216,9 @@ class Fetcher:
                     break
 
                 size = f.write(chunk)
-                progress.update(task_id, advance=size)
+                self.progress.update(task_id, advance=size)
+                if self.overall_task is not None:
+                    self.overall_progress.update(self.overall_task, advance=size)
 
                 # Handle bandwidth limiting, if set
                 if self.bandwidth_limit:
@@ -225,7 +242,6 @@ class Fetcher:
         url: URI | str,
         dest_dir: str,
         filename: str | None = None,
-        progress: Progress | None = None,
         description: str | None = None,
     ) -> None:
         """
@@ -236,7 +252,6 @@ class Fetcher:
         :param str dest_dir: The directory to save the downloaded file to.
         :param filename: The name of the file to use.
         :type filename: str | None
-        :param Progress progress: The rich Progress object to use.
         :param str description: The description for the task.
         """
         # This is silly and I hate it.
@@ -255,7 +270,11 @@ class Fetcher:
             raise IOError(_(f"Unable to access destination file '{archive_file}'"))
 
         try:
-            self.download_file(url, archive_file, progress, description)
+            self.download_file(
+                url,
+                archive_file,
+                description,
+            )
         except HTTPError:
             raise
 
@@ -274,9 +293,13 @@ class Fetcher:
         max_workers = max(1, min(max_workers, 64))
         ctx.ui.debug(_(f"Setting {max_workers} concurrent download workers"))
 
+        total_size = sum(item.size for item in items)
+
+        self.overall_task = self.overall_progress.add_task("Overall", total=total_size)
+
         ctx.sig.catch_signal(signal.SIGINT)
         try:
-            with rich_progress as progress:
+            with self.live:
                 with ThreadPoolExecutor(max_workers=max_workers) as executor:
                     futures = []
 
@@ -291,7 +314,6 @@ class Fetcher:
                                 resource.uri,
                                 os.path.dirname(resource.local_path),
                                 os.path.basename(resource.local_path),
-                                progress,
                                 description,
                             )
                         )
@@ -308,6 +330,10 @@ class Fetcher:
                         raise pisi.Error(
                             _("One or more errors occurred during fetching")
                         )
+
+                    # Update live display with a dummy group clean things up visually
+                    self.live.update(Group())
+
         finally:
             ctx.sig.enable_signal(signal.SIGINT)
 

--- a/pisi/fetcher.py
+++ b/pisi/fetcher.py
@@ -3,6 +3,7 @@
 
 import os
 import shutil
+import signal
 import time
 from concurrent.futures import ThreadPoolExecutor
 
@@ -84,60 +85,68 @@ class Fetcher:
         :param Progress progress: The rich Progress object to use.
         :param str description: The description for the task.
         """
-        if url.is_local_file():
-            source = url.path()
-            rooted_path = pisi.util.join_path(ctx.config.dest_dir(), source)
-            if os.path.exists(rooted_path):
-                source = rooted_path
-            else:
-                raise IOError(_(f"Source file '{source}' does not exist"))
+        ctx.sig.catch_signal(signal.SIGINT)
+        try:
+            if url.is_local_file():
+                source = url.path()
+                rooted_path = pisi.util.join_path(ctx.config.dest_dir(), source)
+                if os.path.exists(rooted_path):
+                    source = rooted_path
+                else:
+                    raise IOError(_(f"Source file '{source}' does not exist"))
 
-            total = os.path.getsize(source)
+                total = os.path.getsize(source)
 
-            if progress is not None:
-                task_id = progress.add_task(
-                    description or os.path.basename(destination),
-                    total=total,
-                )
-                try:
-                    self._copy_to_file(source, destination, progress, task_id)
-                finally:
-                    progress.remove_task(task_id)
-                    progress.console.print(_(f"Copied {os.path.basename(destination)}"))
-            else:
-                with rich_progress as p:
-                    tid = p.add_task(
-                        description or os.path.basename(destination), total=total
+                if progress is not None:
+                    task_id = progress.add_task(
+                        description or os.path.basename(destination),
+                        total=total,
                     )
-                    self._copy_to_file(source, destination, p, tid)
-            return
+                    try:
+                        self._copy_to_file(source, destination, progress, task_id)
+                    finally:
+                        progress.remove_task(task_id)
+                        progress.console.print(
+                            _(f"Copied {os.path.basename(destination)}")
+                        )
+                else:
+                    with rich_progress as p:
+                        tid = p.add_task(
+                            description or os.path.basename(destination), total=total
+                        )
+                        self._copy_to_file(source, destination, p, tid)
+                return
 
-        with self.session.get(url.get_uri(), stream=True, timeout=15) as resp:
-            resp.raise_for_status()
-            start_time = time.time()
+            with self.session.get(url.get_uri(), stream=True, timeout=15) as resp:
+                resp.raise_for_status()
+                start_time = time.time()
 
-            total = int(resp.headers.get("Content-Length") or 0)
+                total = int(resp.headers.get("Content-Length") or 0)
 
-            if progress is not None:
-                task_id = progress.add_task(
-                    description or os.path.basename(destination),
-                    total=total,
-                )
-                try:
-                    self._download_to_file(
-                        resp, destination, start_time, progress, task_id
+                if progress is not None:
+                    task_id = progress.add_task(
+                        description or os.path.basename(destination),
+                        total=total,
                     )
-                finally:
-                    progress.remove_task(task_id)
-                    progress.console.print(
-                        _(f"Downloaded {os.path.basename(destination)}")
-                    )
-            else:
-                with rich_progress as p:
-                    tid = p.add_task(
-                        description or os.path.basename(destination), total=total
-                    )
-                    self._download_to_file(resp, destination, start_time, p, tid)
+                    try:
+                        self._download_to_file(
+                            resp, destination, start_time, progress, task_id
+                        )
+                    finally:
+                        progress.remove_task(task_id)
+                        progress.console.print(
+                            _(f"Downloaded {os.path.basename(destination)}")
+                        )
+                else:
+                    with rich_progress as p:
+                        tid = p.add_task(
+                            description or os.path.basename(destination), total=total
+                        )
+                        self._download_to_file(resp, destination, start_time, p, tid)
+        finally:
+            ctx.sig.enable_signal(signal.SIGINT)
+
+        ctx.sig.check_signals()
 
     def _copy_to_file(
         self,
@@ -189,6 +198,10 @@ class Fetcher:
                         time.sleep(expected_time - elapsed)
 
                         start_time = time.time()
+
+                # Handle SIGINT in ThreadPoolExecutor context
+                if ctx.sig.done_event.is_set():
+                    return
 
     def fetch(
         self,
@@ -244,32 +257,38 @@ class Fetcher:
         max_workers = max(1, min(max_workers, 64))
         ctx.ui.debug(_(f"Setting {max_workers} concurrent download workers"))
 
-        with rich_progress as progress:
-            with ThreadPoolExecutor(max_workers=max_workers) as executor:
-                futures = []
+        ctx.sig.catch_signal(signal.SIGINT)
+        try:
+            with rich_progress as progress:
+                with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                    futures = []
 
-                for resource in items:
-                    description = f"{resource.name} ({resource.repo})"
-                    if resource.is_delta:
-                        description += " [delta]"
+                    for resource in items:
+                        description = f"{resource.name} ({resource.repo})"
+                        if resource.is_delta:
+                            description += " [delta]"
 
-                    futures.append(
-                        executor.submit(
-                            self.fetch,
-                            resource.uri,
-                            os.path.dirname(resource.local_path),
-                            os.path.basename(resource.local_path),
-                            progress,
-                            description,
+                        futures.append(
+                            executor.submit(
+                                self.fetch,
+                                resource.uri,
+                                os.path.dirname(resource.local_path),
+                                os.path.basename(resource.local_path),
+                                progress,
+                                description,
+                            )
                         )
-                    )
 
-                for future in futures:
-                    try:
-                        future.result()
-                    except Exception as e:
-                        ctx.ui.error(str(e))
-                        raise
+                    for future in futures:
+                        try:
+                            future.result()
+                        except Exception as e:
+                            ctx.ui.error(str(e))
+                            raise
+        finally:
+            ctx.sig.enable_signal(signal.SIGINT)
+
+        ctx.sig.check_signals()
 
     def _get_bandwidth_limit(self) -> int:
         bandwidth_limit = (

--- a/pisi/fetcher.py
+++ b/pisi/fetcher.py
@@ -66,7 +66,7 @@ class Fetcher:
             with (
                 open(destination, "wb") as f,
                 tqdm(
-                    desc=destination,
+                    desc=os.path.basename(destination),
                     total=total,
                     unit="iB",
                     unit_scale=True,

--- a/pisi/fetcher.py
+++ b/pisi/fetcher.py
@@ -124,6 +124,7 @@ class Fetcher:
                         time.sleep(expected_time - elapsed)
 
                         start_time = time.time()
+            progress.remove_task(task_id)
 
     def fetch(
         self,

--- a/pisi/fetcher.py
+++ b/pisi/fetcher.py
@@ -27,6 +27,18 @@ from pisi.util import human_readable_rate
 """Maximum size in bytes of a download chunk to process at a time."""
 MAX_CHUNK_SIZE = 8192
 
+rich_progress = Progress(
+    TextColumn("[bold blue]{task.description}", justify="right"),
+    BarColumn(bar_width=None),
+    "[progress.percentage]{task.percentage:>3.1f}%",
+    "•",
+    DownloadColumn(),
+    "•",
+    TransferSpeedColumn(),
+    "•",
+    TimeRemainingColumn(),
+)
+
 
 class Fetcher:
     """Handles an HTTP session for making one or more download requests.
@@ -58,18 +70,18 @@ class Fetcher:
 
     def download_file(
         self,
-        url: str,
+        url: URI,
         destination: str,
         progress: Progress | None = None,
-        task_id: TaskID | None = None,
+        description: str | None = None,
     ) -> None:
         """
         Download a remote resource to a local file.
 
-        :param str url: The URL of the resource to download.
+        :param URI url: The URI of the resource to download.
         :param str destination: The destination file to download to.
         :param Progress progress: The rich Progress object to use.
-        :param TaskID task_id: The rich TaskID to use.
+        :param str description: The description for the task.
         """
         with self.session.get(url.get_uri(), stream=True, timeout=15) as resp:
             resp.raise_for_status()
@@ -77,23 +89,25 @@ class Fetcher:
 
             total = int(resp.headers.get("Content-Length") or 0)
 
-            if progress is not None and task_id is not None:
-                progress.update(task_id, total=total)
-                progress.start_task(task_id)
-                self._download_to_file(resp, destination, start_time, progress, task_id)
+            if progress is not None:
+                task_id = progress.add_task(
+                    description or os.path.basename(destination),
+                    total=total,
+                )
+                try:
+                    self._download_to_file(
+                        resp, destination, start_time, progress, task_id
+                    )
+                finally:
+                    progress.remove_task(task_id)
+                    progress.console.print(
+                        _(f"Downloaded {os.path.basename(destination)}")
+                    )
             else:
-                with Progress(
-                    TextColumn("[bold blue]{task.description}", justify="right"),
-                    BarColumn(bar_width=None),
-                    "[progress.percentage]{task.percentage:>3.1f}%",
-                    "•",
-                    DownloadColumn(),
-                    "•",
-                    TransferSpeedColumn(),
-                    "•",
-                    TimeRemainingColumn(),
-                ) as p:
-                    tid = p.add_task(os.path.basename(destination), total=total)
+                with rich_progress as p:
+                    tid = p.add_task(
+                        description or os.path.basename(destination), total=total
+                    )
                     self._download_to_file(resp, destination, start_time, p, tid)
 
     def _download_to_file(
@@ -124,7 +138,6 @@ class Fetcher:
                         time.sleep(expected_time - elapsed)
 
                         start_time = time.time()
-            progress.remove_task(task_id)
 
     def fetch(
         self,
@@ -132,7 +145,7 @@ class Fetcher:
         dest_dir: str,
         filename: str | None = None,
         progress: Progress | None = None,
-        task_id: TaskID | None = None,
+        description: str | None = None,
     ) -> None:
         """
         Fetches a remote resource.
@@ -143,7 +156,7 @@ class Fetcher:
         :param filename: The name of the file to use.
         :type filename: str | None
         :param Progress progress: The rich Progress object to use.
-        :param TaskID task_id: The rich TaskID to use.
+        :param str description: The description for the task.
         """
         # This is silly and I hate it.
         if type(url) is str:
@@ -161,15 +174,15 @@ class Fetcher:
             raise IOError(_(f"Unable to access destination file '{archive_file}'"))
 
         try:
-            self.download_file(url, archive_file, progress, task_id)
+            self.download_file(url, archive_file, progress, description)
         except HTTPError:
             raise
 
-    def fetch_multi(self, items: list) -> None:
+    def fetch_multi(self, items: list["pisi.package.PackageResource"]) -> None:
         """
         Fetches multiple remote resources concurrently.
 
-        :param items: A list of (url, dest_dir, filename) tuples.
+        :param items: A list of PackageResource objects.
         """
 
         max_workers = int(
@@ -180,37 +193,23 @@ class Fetcher:
         max_workers = max(1, min(max_workers, 64))
         ctx.ui.debug(_(f"Setting {max_workers} concurrent download workers"))
 
-        with Progress(
-            TextColumn("[bold blue]{task.description}", justify="right"),
-            BarColumn(bar_width=None),
-            "[progress.percentage]{task.percentage:>3.1f}%",
-            "•",
-            DownloadColumn(),
-            "•",
-            TransferSpeedColumn(),
-            "•",
-            TimeRemainingColumn(),
-        ) as progress:
+        with rich_progress as progress:
             with ThreadPoolExecutor(max_workers=max_workers) as executor:
                 futures = []
 
-                for i, item in enumerate(items):
-                    url, dest_dir, *rest = item
-                    filename = rest[0] if rest else None
-
-                    # This is silly and I hate it.
-                    if type(url) is str:
-                        u = URI(url)
-                    else:
-                        u = url
-
-                    task_id = progress.add_task(
-                        filename or u.filename(), total=None, start=False
-                    )
+                for resource in items:
+                    description = f"{resource.name} ({resource.repo})"
+                    if resource.is_delta:
+                        description += " [delta]"
 
                     futures.append(
                         executor.submit(
-                            self.fetch, url, dest_dir, filename, progress, task_id
+                            self.fetch,
+                            resource.uri,
+                            os.path.dirname(resource.local_path),
+                            os.path.basename(resource.local_path),
+                            progress,
+                            description,
                         )
                     )
 

--- a/pisi/fetcher.py
+++ b/pisi/fetcher.py
@@ -296,12 +296,18 @@ class Fetcher:
                             )
                         )
 
+                    any_errors = False
                     for future in futures:
                         try:
                             future.result()
                         except Exception as e:
                             ctx.ui.error(str(e))
-                            raise
+                            any_errors = True
+
+                    if any_errors:
+                        raise pisi.Error(
+                            _("One or more errors occurred during fetching")
+                        )
         finally:
             ctx.sig.enable_signal(signal.SIGINT)
 

--- a/pisi/fetcher.py
+++ b/pisi/fetcher.py
@@ -136,9 +136,7 @@ class Fetcher:
                 finally:
                     self.progress.remove_task(task_id)
                     self.progress.console.print(
-                        _(
-                            f"[bold yellow]Copied[reset] {os.path.basename(destination)}"
-                        ),
+                        _(f"[green]Copied[reset] {os.path.basename(destination)}"),
                         highlight=False,
                     )
 
@@ -161,9 +159,7 @@ class Fetcher:
                 finally:
                     self.progress.remove_task(task_id)
                     self.progress.console.print(
-                        _(
-                            f"[bold yellow]Downloaded[reset] {os.path.basename(destination)}"
-                        ),
+                        _(f"[green]Downloaded[reset] {os.path.basename(destination)}"),
                         highlight=False,
                     )
         finally:

--- a/pisi/fetcher.py
+++ b/pisi/fetcher.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 import os
+import shutil
 import time
 from concurrent.futures import ThreadPoolExecutor
 
@@ -83,6 +84,34 @@ class Fetcher:
         :param Progress progress: The rich Progress object to use.
         :param str description: The description for the task.
         """
+        if url.is_local_file():
+            source = url.path()
+            rooted_path = pisi.util.join_path(ctx.config.dest_dir(), source)
+            if os.path.exists(rooted_path):
+                source = rooted_path
+            else:
+                raise IOError(_(f"Source file '{source}' does not exist"))
+
+            total = os.path.getsize(source)
+
+            if progress is not None:
+                task_id = progress.add_task(
+                    description or os.path.basename(destination),
+                    total=total,
+                )
+                try:
+                    self._copy_to_file(source, destination, progress, task_id)
+                finally:
+                    progress.remove_task(task_id)
+                    progress.console.print(_(f"Copied {os.path.basename(destination)}"))
+            else:
+                with rich_progress as p:
+                    tid = p.add_task(
+                        description or os.path.basename(destination), total=total
+                    )
+                    self._copy_to_file(source, destination, p, tid)
+            return
+
         with self.session.get(url.get_uri(), stream=True, timeout=15) as resp:
             resp.raise_for_status()
             start_time = time.time()
@@ -109,6 +138,28 @@ class Fetcher:
                         description or os.path.basename(destination), total=total
                     )
                     self._download_to_file(resp, destination, start_time, p, tid)
+
+    def _copy_to_file(
+        self,
+        source: str,
+        destination: str,
+        progress: Progress,
+        task_id: TaskID,
+    ) -> None:
+        # Try hardlinking first
+        try:
+            if os.path.exists(destination):
+                os.unlink(destination)
+            os.link(source, destination)
+            progress.update(task_id, completed=os.path.getsize(source))
+            return
+        except OSError:
+            # Fallback to manual copy with progress
+            pass
+
+        with progress.open(source, "rb", task_id=task_id) as src:
+            with open(destination, "wb") as dst:
+                shutil.copyfileobj(src, dst)
 
     def _download_to_file(
         self,

--- a/pisi/fetcher.py
+++ b/pisi/fetcher.py
@@ -1,319 +1,160 @@
-# SPDX-FileCopyrightText: 2005-2011 TUBITAK/UEKAE, 2013-2017 Ikey Doherty, Solus Project
+# SPDX-FileCopyrightText: 2005-2011 TUBITAK/UEKAE, 2013-2017 Ikey Doherty, Solus Project, 2026 Solus Project
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-"""Yet another Pisi module for fetching files from various sources. Of
-course, this is not limited to just fetching source files. We fetch
-all kinds of things: source tarballs, index files, packages, and God
-knows what."""
-
-# python standard library modules
-import base64
-import contextlib
 import os
-import shutil
 import time
-import urllib.error
-import urllib.parse
-import urllib.request
-from urllib.error import URLError
 
-# pisi modules
+import requests
+from requests import HTTPError
+from requests.adapters import HTTPAdapter
+
+from tqdm import tqdm
+
 import pisi
 import pisi.context as ctx
-import pisi.uri
-import pisi.util as util
+
 from pisi import translate as _
+from pisi.uri import URI
 
-
-class FetchError(pisi.Error):
-    pass
-
-
-class FetchHandler:
-    def __init__(self, url, archive, bandwidth_limit, start_time):
-        self.url = url
-        self.percent = None
-        self.rate = 0.0
-        self.size = 0
-        self.eta = "--:--:--"
-        self.symbol = "--/-"
-        self.last_updated = 0
-        self.filename = url.filename()
-        self.total_size = 0.0
-        self.exist_size = 0
-        self.bandwidth_limit = bandwidth_limit
-        if os.path.exists(archive):
-            self.exist_size = os.path.getsize(archive)
-
-        self.now = lambda: time.time()
-        self.t_diff = lambda: self.now() - self.s_time
-        self.e_diff = lambda: self.now() - start_time
-
-        self.s_time = self.now()
-
-    def update(self, blocknum, bs, size):
-        self.total_size = size + self.exist_size
-        self.size = blocknum * bs + self.exist_size
-        if self.total_size:
-            self.percent = self.size * 100.0 / self.total_size
-            if self.percent > 100:
-                self.percent = 100
-        else:
-            self.percent = 0
-
-        if int(self.now()) != int(self.last_updated) and self.size > 0:
-            try:
-                self.rate, self.symbol = util.human_readable_rate(
-                    (self.size - self.exist_size) / (self.now() - self.s_time)
-                )
-            except ZeroDivisionError:
-                return
-            if self.total_size:
-                self.eta = "%02d:%02d:%02d" % tuple(
-                    [
-                        i
-                        for i in time.gmtime(
-                            (self.e_diff() * (100 - self.percent)) / self.percent
-                        )[3:6]
-                    ]
-                )
-
-        self._update_ui()
-        self._limit_bandwidth()
-
-    def _limit_bandwidth(self):
-        if self.bandwidth_limit:
-            expected_time = (self.size - self.exist_size) / self.bandwidth_limit
-            sleep_time = expected_time - self.t_diff()
-            if sleep_time > 0:
-                time.sleep(sleep_time)
-
-    def _update_ui(self):
-        ctx.ui.display_progress(
-            operation="fetching",
-            percent=self.percent,
-            filename=self.filename,
-            total_size=self.total_size or self.size,
-            downloaded_size=self.size,
-            rate=self.rate,
-            eta=self.eta,
-            symbol=self.symbol,
-        )
-
-        self.last_updated = self.now()
+"""Maximum size in bytes of a download chunk to process at a time."""
+MAX_CHUNK_SIZE = 8192
 
 
 class Fetcher:
-    """Fetcher can fetch a file from various sources using various
-    protocols."""
+    """Handles an HTTP session for making one or more download requests.
 
-    def __init__(self, url, destdir="/tmp", destfile=None):
-        if not isinstance(url, pisi.uri.URI):
-            url = pisi.uri.URI(url)
+    It supports automatic retries (http/https only), bandwidth limits,
+    and network proxies. Values for these settings are read from the
+    global config via the Pisi context. This may change in the future.
 
-        self.url = url
-        self.destdir = destdir
-        self.destfile = destfile
-        self.progress = None
+    Attributes:
+        bandwidth_limit (int): The speed in bits per second that shall
+            not be exceeded during downloads. Set to 0 for no limit.
+        max_retries (int): The maximum number of times that a download
+            can be retried before giving up. Default 5
+        session (requests.Session): The HTTP session.
+    """
 
-        self.archive_file = os.path.join(destdir, destfile or url.filename())
-        self.partial_file = (
-            os.path.join(self.destdir, self.url.filename()) + ctx.const.partial_suffix
-        )
+    def __init__(self):
+        self.bandwidth_limit = self._get_bandwidth_limit()
+        self.max_retries = self._get_max_retries()
 
-        util.ensure_dirs(self.destdir)
+        self.session = requests.Session()
 
-    def fetch(self):
-        """Return value: Fetched file's full path.."""
+        self.session.mount("http://", HTTPAdapter(max_retries=self.max_retries))
+        self.session.mount("https://", HTTPAdapter(max_retries=self.max_retries))
+        self.session.headers.update({"User-Agent": f"eopkg Fetcher/{pisi.__version__}"})
 
-        if not self.url.filename():
-            raise FetchError(_("Filename error"))
+        proxies = self._get_proxies()
+        self.session.proxies.update(proxies)
 
-        if self.url.is_local_file():
-            source = os.path.normpath(self.url.path())
-            if not os.path.exists(source):
-                raise FetchError(_("File not found: %s") % source)
+    def download_file(self, url: str, destination: str) -> None:
+        """
+        Download a remote resource to a local file.
 
-            if source != self.archive_file:
-                shutil.copy(source, self.archive_file)
+        :param str url: The URL of the resource to download.
+        :param str destination: The destination file to download to.
+        """
+        with self.session.get(url.get_uri(), stream=True, timeout=15) as resp:
+            resp.raise_for_status()
+            start_time = time.time()
 
-            return self.archive_file
+            total = int(resp.headers.get("Content-Length"), 0)
 
-        if not os.access(self.destdir, os.W_OK):
-            raise FetchError(
-                _('Access denied to write to destination directory: "%s"')
-                % self.destdir
-            )
+            with (
+                open(destination, "wb") as f,
+                tqdm(
+                    desc=destination,
+                    total=total,
+                    unit="iB",
+                    unit_scale=True,
+                    unit_divisor=1024,
+                ) as bar,
+            ):
+                for chunk in resp.iter_content(chunk_size=MAX_CHUNK_SIZE):
+                    if not chunk:
+                        # TODO(Evan): Figure out what to do here
+                        break
 
-        if os.path.exists(self.archive_file) and not os.access(
-            self.archive_file, os.W_OK
-        ):
-            raise FetchError(
-                _('Access denied to destination file: "%s"') % self.archive_file
-            )
+                    size = f.write(chunk)
+                    bar.update(size)
 
-        attempt = 0
-        success = False
+                    # Handle bandwidth limiting, if set
+                    if self.bandwidth_limit:
+                        elapsed = time.time() - start_time
+                        # Calculate the time this chunk "should" take to stay
+                        # under the limit
+                        expected_time = MAX_CHUNK_SIZE / self.bandwidth_limit
 
-        self.now = lambda: time.time()
-        self.start_time = self.now()
+                        # Sleep the difference
+                        if elapsed < expected_time:
+                            time.sleep(expected_time - elapsed)
 
-        while success is False and attempt < self._get_retry_attempts() + 1:
-            try:
-                fetch_handler = FetchHandler(
-                    self.url,
-                    self.partial_file,
-                    self._get_bandwidth_limit(),
-                    self.start_time,
-                )
+    def fetch(self, url: URI | str, dest_dir: str, filename: str = None) -> None:
+        """
+        Fetches a remote resource.
 
-                proxy = urllib.request.ProxyHandler(self._get_proxies())
-                opener = urllib.request.build_opener(proxy)
-                opener.addheaders = self._get_headers()
-                urllib.request.install_opener(opener)
-                has_range_support = self._test_range_support()
+        :param url: The file to fetch.
+        :type url: pisi.uri.URI | str
+        :param str dest_dir: The directory to save the downloaded file to.
+        :param filename: The name of the file to use.
+        :type filename: str | None
+        """
+        # This is silly and I hate it.
+        if type(url) is str:
+            url = URI(url)
 
-                if has_range_support and os.path.exists(self.partial_file):
-                    partial_file_size = os.path.getsize(self.partial_file)
-                    opener.addheaders.append(("Range", "bytes=%s-" % partial_file_size))
+        if not url.filename():
+            raise ValueError(_("URL does not end in a file name"))
 
-                with contextlib.closing(
-                    urllib.request.urlopen(self.url.get_uri(), timeout=15)
-                ) as fp:
-                    headers = fp.info()
+        if not os.access(dest_dir, os.W_OK):
+            raise IOError(_(f"Unable to access destination directory '{dest_dir}'"))
 
-                    if has_range_support:
-                        tfp = open(self.partial_file, "ab")
-                    else:
-                        tfp = open(self.partial_file, "wb")
+        archive_file = os.path.join(dest_dir, filename or url.filename())
 
-                    with tfp:
-                        bs = 1024 * 8
-                        size = -1
-                        read = 0
-                        blocknum = 0
-                        if "content-length" in headers:
-                            size = int(headers["Content-Length"])
-                        fetch_handler.update(blocknum, bs, size)
-                        while True:
-                            block = fp.read(bs)
-                            if not block:
-                                break
-                            read += len(block)
-                            tfp.write(block)
-                            blocknum += 1
-                            fetch_handler.update(blocknum, bs, size)
-                    success = True
-            except URLError as e:
-                attempt += 1
-                if attempt == self._get_retry_attempts() + 1:
-                    raise FetchError(
-                        _('Hit max retry count when downloading: "%s"')
-                        % (self.url.get_uri())
-                    )
-                ctx.ui.warning(
-                    _('\nFailed to fetch file, retrying %d out of %d "%s": %s')
-                    % (attempt, self._get_retry_attempts(), self.url.get_uri(), e)
-                )
-                pass
+        if os.path.exists(archive_file) and not os.access(archive_file, os.W_OK):
+            raise IOError(_(f"Unable to access destination file '{archive_file}'"))
 
-        if os.stat(self.partial_file).st_size == 0:
-            os.remove(self.partial_file)
-            raise FetchError(
-                _(
-                    "A problem occurred. Please check the archive address and/or permissions again."
-                )
-            )
+        try:
+            self.download_file(url, archive_file)
+        except HTTPError:
+            raise
 
-        shutil.move(self.partial_file, self.archive_file)
-
-        return self.archive_file
-
-    def _get_headers(self):
-        headers = []
-        headers.append(("User-Agent", "eopkg Fetcher/" + pisi.__version__))
-        return headers
-
-    def _get_proxies(self):
-        proxies = {}
-
-        if ctx.config.values.general.http_proxy and self.url.scheme() == "http":
-            proxies[pisi.uri.URI(ctx.config.values.general.http_proxy).scheme()] = (
-                ctx.config.values.general.http_proxy
-            )
-
-        if ctx.config.values.general.https_proxy and self.url.scheme() == "https":
-            proxies[pisi.uri.URI(ctx.config.values.general.https_proxy).scheme()] = (
-                ctx.config.values.general.https_proxy
-            )
-
-        if ctx.config.values.general.ftp_proxy and self.url.scheme() == "ftp":
-            proxies[pisi.uri.URI(ctx.config.values.general.ftp_proxy).scheme()] = (
-                ctx.config.values.general.ftp_proxy
-            )
-
-        if self.url.scheme() in proxies:
-            ctx.ui.info(
-                _("Proxy configuration has been found for '%s' protocol")
-                % self.url.scheme()
-            )
-
-        return proxies
-
-    def _get_bandwidth_limit(self):
+    def _get_bandwidth_limit(self) -> int:
         bandwidth_limit = (
             ctx.config.options.bandwidth_limit
             or ctx.config.values.general.bandwidth_limit
         )
+
+        # TODO(Evan): Figure out if there's a mismatch between config units
+        # and units used to calculate the limiter
         if bandwidth_limit and bandwidth_limit != "0":
-            ctx.ui.warning(_("Bandwidth usage is limited to %s KB/s") % bandwidth_limit)
+            ctx.ui.warning(_(f"Bandwidth usage is limited to {bandwidth_limit} KB/s"))
             return 1024 * int(bandwidth_limit)
         else:
             return 0
 
-    def _get_retry_attempts(self):
+    def _get_max_retries(self) -> int:
         retry_attempts = (
             ctx.config.options.retry_attempts
             or ctx.config.values.general.retry_attempts
         )
+
         if retry_attempts and retry_attempts != "5":
             return int(retry_attempts)
         else:
             return 5
 
-    def _test_range_support(self):
-        if not os.path.exists(self.partial_file):
-            return False
+    def _get_proxies(self) -> dict:
+        proxies = {}
 
-        try:
-            file_obj = urllib.request.urlopen(
-                urllib.request.Request(self.url.get_uri())
-            )
-        except urllib.error.URLError:
-            ctx.ui.debug(
-                _(
-                    "Remote file can not be reached. Previously downloaded part of the file will be removed."
-                )
-            )
-            os.remove(self.partial_file)
-            return False
+        if ctx.config.values.general.http_proxy and self.url.scheme() == "http":
+            proxies["http"] = ctx.config.values.general.http_proxy
 
-        headers = file_obj.info()
-        file_obj.close()
-        if "Content-Length" in headers:
-            return True
-        else:
-            ctx.ui.debug(
-                _(
-                    "Server doesn't support partial downloads. Previously downloaded part of the file will be over-written."
-                )
-            )
-            os.remove(self.partial_file)
-            return False
+        if ctx.config.values.general.https_proxy and self.url.scheme() == "https":
+            proxies["https"] = ctx.config.values.general.https_proxy
 
+        if ctx.config.values.general.ftp_proxy and self.url.scheme() == "ftp":
+            proxies["ftp"] = ctx.config.values.general.ftp_proxy
 
-# helper function
-def fetch_url(url, destdir, progress=None, destfile=None):
-    fetch = Fetcher(url, destdir, destfile)
-    fetch.progress = progress
-    fetch.fetch()
+        return proxies

--- a/pisi/fetcher.py
+++ b/pisi/fetcher.py
@@ -14,6 +14,7 @@ import pisi
 import pisi.context as ctx
 from pisi import translate as _
 from pisi.uri import URI
+from pisi.util import human_readable_rate
 
 """Maximum size in bytes of a download chunk to process at a time."""
 MAX_CHUNK_SIZE = 8192
@@ -93,6 +94,8 @@ class Fetcher:
                         if elapsed < expected_time:
                             time.sleep(expected_time - elapsed)
 
+                        start_time = time.time()
+
     def fetch(
         self,
         url: URI | str,
@@ -171,11 +174,13 @@ class Fetcher:
             or ctx.config.values.general.bandwidth_limit
         )
 
-        # TODO(Evan): Figure out if there's a mismatch between config units
-        # and units used to calculate the limiter
         if bandwidth_limit and bandwidth_limit != "0":
-            ctx.ui.warning(_(f"Bandwidth usage is limited to {bandwidth_limit} KB/s"))
-            return 1024 * int(bandwidth_limit)
+            # The limit is in KB
+            bandwidth_limit = int(bandwidth_limit) * 1000
+            parts = human_readable_rate(bandwidth_limit)
+            rate = f"{parts[0]} {parts[1]}"
+            ctx.ui.warning(_(f"Bandwidth usage is limited to {rate}"))
+            return bandwidth_limit
         else:
             return 0
 

--- a/pisi/fetcher.py
+++ b/pisi/fetcher.py
@@ -142,7 +142,15 @@ class Fetcher:
                         tid = p.add_task(
                             description or os.path.basename(destination), total=total
                         )
-                        self._download_to_file(resp, destination, start_time, p, tid)
+                        try:
+                            self._download_to_file(
+                                resp, destination, start_time, p, tid
+                            )
+                        finally:
+                            p.remove_task(tid)
+                            p.console.print(
+                                _(f"Downloaded {os.path.basename(destination)}")
+                            )
         finally:
             ctx.sig.enable_signal(signal.SIGINT)
 

--- a/pisi/file.py
+++ b/pisi/file.py
@@ -15,11 +15,11 @@ import shutil
 import lzma_mt
 
 import pisi
-import pisi.fetcher
 import pisi.uri
 import pisi.util
 from pisi import context as ctx
 from pisi import translate as _
+from pisi.fetcher import Fetcher
 
 
 class AlreadyHaveException(pisi.Exception):
@@ -139,8 +139,10 @@ class File:
                     raise AlreadyHaveException(uri, origfile)
 
             if uri.is_remote_file():
-                ctx.ui.info(_("Fetching %s") % uri.get_uri(), verbose=True)
-                pisi.fetcher.fetch_url(uri, transfer_dir, ctx.ui.Progress, tmpfile)
+                ctx.ui.info(_(f"Fetching {uri.get_uri}"), verbose=True)
+                fetcher = Fetcher()
+                # TODO(Evan): Error handling
+                fetcher.fetch(uri, transfer_dir, tmpfile)
             else:
                 # copy to transfer dir
                 ctx.ui.info(

--- a/pisi/file.py
+++ b/pisi/file.py
@@ -19,7 +19,6 @@ import pisi.uri
 import pisi.util
 from pisi import context as ctx
 from pisi import translate as _
-from pisi.fetcher import Fetcher
 
 
 class AlreadyHaveException(pisi.Exception):
@@ -140,6 +139,8 @@ class File:
 
             if uri.is_remote_file():
                 ctx.ui.info(_(f"Fetching {uri.get_uri}"), verbose=True)
+                from pisi.fetcher import Fetcher
+
                 fetcher = Fetcher()
                 # TODO(Evan): Error handling
                 fetcher.fetch(uri, transfer_dir, tmpfile)

--- a/pisi/index.py
+++ b/pisi/index.py
@@ -3,24 +3,22 @@
 
 """eopkg source/package index"""
 
+import multiprocessing
 import os
 import shutil
-import multiprocessing
-
-from pisi import translate as _
 
 import pisi
-import pisi.context as ctx
-import pisi.specfile as specfile
-import pisi.metadata as metadata
-import pisi.util as util
-import pisi.package
-import pisi.pxml.xmlfile as xmlfile
-import pisi.file
-import pisi.pxml.autoxml as autoxml
 import pisi.component as component
+import pisi.context as ctx
+import pisi.file
 import pisi.group as group
-import pisi.operations.build
+import pisi.metadata as metadata
+import pisi.package
+import pisi.pxml.autoxml as autoxml
+import pisi.pxml.xmlfile as xmlfile
+import pisi.specfile as specfile
+import pisi.util as util
+from pisi import translate as _
 
 
 class Error(pisi.Error):
@@ -169,7 +167,8 @@ def add_package(params):
             ctx.ui.info("  %s" % os.path.basename(path))
         else:
             ctx.ui.info(
-                "%-80.80s\r" % (_("Adding package to index: %s") % os.path.basename(path)),
+                "%-80.80s\r"
+                % (_("Adding package to index: %s") % os.path.basename(path)),
                 noln=True,
             )
 
@@ -273,7 +272,9 @@ def add_spec(params):
     try:
         path, repo_uri = params
         # TODO: may use try/except to handle this
-        builder = pisi.operations.build.Builder(path)
+        from pisi.operations.build import Builder
+
+        builder = Builder(path)
         builder.fetch_component()
         sf = builder.spec
         if ctx.config.options and ctx.config.options.absolute_urls:

--- a/pisi/operations/build.py
+++ b/pisi/operations/build.py
@@ -31,7 +31,6 @@ import pisi.specfile
 import pisi.uri
 import pisi.util as util
 from pisi import translate as _
-from pisi.fetcher import Fetcher
 
 
 class Error(pisi.Error):
@@ -527,6 +526,8 @@ class Builder:
         parentdir = util.parenturi(diruri)
         url = util.join_path(parentdir, "component.xml")
         if pisi.uri.URI(url).is_remote_file():
+            from pisi.fetcher import Fetcher
+
             fetcher = Fetcher()
 
             try:

--- a/pisi/operations/build.py
+++ b/pisi/operations/build.py
@@ -529,7 +529,6 @@ class Builder:
         if pisi.uri.URI(url).is_remote_file():
             fetcher = Fetcher()
 
-            # TODO(Evan): wat
             try:
                 fetcher.fetch(url, self.pkg_work_dir())
             except HTTPError | IOError | ValueError:

--- a/pisi/operations/build.py
+++ b/pisi/operations/build.py
@@ -4,35 +4,34 @@
 """package building code"""
 
 # python standard library
-import os
-import re
-import glob
-import stat
-import pwd
-import grp
 import fnmatch
-
-from pisi import translate as _
-
-import pisi
-import pisi.specfile
-import pisi.util as util
-import pisi.file
-import pisi.context as ctx
-import pisi.dependency as dependency
-import pisi.api
-import pisi.sourcearchive
-import pisi.files
-import pisi.fetcher
-import pisi.uri
-import pisi.metadata
-import pisi.package
-import pisi.component as component
-import pisi.archive as archive
-import pisi.actionsapi.variables
-import pisi.db
+import glob
+import grp
+import os
+import pwd
+import re
+import stat
 
 import magic
+from requests import HTTPError
+
+import pisi
+import pisi.actionsapi.variables
+import pisi.api
+import pisi.component as component
+import pisi.context as ctx
+import pisi.db
+import pisi.dependency as dependency
+import pisi.file
+import pisi.files
+import pisi.metadata
+import pisi.package
+import pisi.sourcearchive
+import pisi.specfile
+import pisi.uri
+import pisi.util as util
+from pisi import translate as _
+from pisi.fetcher import Fetcher
 
 
 class Error(pisi.Error):
@@ -382,10 +381,7 @@ class Builder:
                 ctx.ui.info(_("ccache detected..."))
             if self.has_icecream:
                 ctx.ui.info(
-                    _(
-                        "IceCream detected. Make sure your daemon "
-                        "is up and running..."
-                    )
+                    _("IceCream detected. Make sure your daemon is up and running...")
                 )
 
             self.run_setup_action()
@@ -530,11 +526,13 @@ class Builder:
         diruri = util.parenturi(self.specuri.get_uri())
         parentdir = util.parenturi(diruri)
         url = util.join_path(parentdir, "component.xml")
-        progress = ctx.ui.Progress
         if pisi.uri.URI(url).is_remote_file():
+            fetcher = Fetcher()
+
+            # TODO(Evan): wat
             try:
-                pisi.fetcher.fetch_url(url, self.pkg_work_dir(), progress)
-            except pisi.fetcher.FetchError:
+                fetcher.fetch(url, self.pkg_work_dir())
+            except HTTPError | IOError | ValueError:
                 ctx.ui.warning(
                     _(
                         "Cannot find component.xml in remote "
@@ -811,16 +809,13 @@ class Builder:
 
                 if not path.startswith("/"):
                     raise Error(
-                        _(
-                            "Source package '%s' defines a relative 'Path' element: "
-                            "%s"
-                        )
+                        _("Source package '%s' defines a relative 'Path' element: %s")
                         % (self.spec.source.name, path_info.path)
                     )
 
                 if path in paths:
                     raise Error(
-                        _("Source package '%s' defines multiple 'Path' tags " "for %s")
+                        _("Source package '%s' defines multiple 'Path' tags for %s")
                         % (self.spec.source.name, path_info.path)
                     )
 
@@ -1562,15 +1557,14 @@ class Builder:
                         os.chown(dest, pwd.getpwnam(afile.owner)[2], -1)
                     except KeyError:
                         ctx.ui.warning(
-                            _("No user named '%s' found " "on the system") % afile.owner
+                            _("No user named '%s' found on the system") % afile.owner
                         )
                 if afile.group:
                     try:
                         os.chown(dest, -1, grp.getgrnam(afile.group)[2])
                     except KeyError:
                         ctx.ui.warning(
-                            _("No group named '%s' found " "on the system")
-                            % afile.group
+                            _("No group named '%s' found on the system") % afile.group
                         )
         os.chdir(c)
 
@@ -1578,8 +1572,7 @@ class Builder:
         abandoned_files = self.get_abandoned_files()
         if abandoned_files:
             ctx.ui.error(
-                _("There are abandoned files " "under the install dir (%s):")
-                % install_dir
+                _("There are abandoned files under the install dir (%s):") % install_dir
             )
 
             for f in abandoned_files:

--- a/pisi/operations/helper.py
+++ b/pisi/operations/helper.py
@@ -158,11 +158,10 @@ def fetch_packages(order):
                 os.path.exists(r.local_path)
                 and util.sha1_file(r.local_path) == r.expected_hash
             ):
+                ctx.ui.info(_(f"{r.uri.filename()} [cached]"))
                 continue
 
-            items_to_fetch.append(
-                (r.uri, os.path.dirname(r.local_path), r.uri.filename())
-            )
+            items_to_fetch.append(r)
 
     if items_to_fetch:
         fetcher = Fetcher()

--- a/pisi/operations/helper.py
+++ b/pisi/operations/helper.py
@@ -123,12 +123,12 @@ def calculate_download_sizes(order):
     total_size = sum(r.size for r in resources)
     cached_size = 0
     for r in resources:
-        if os.path.exists(r.local_path):
-            if util.sha1_file(r.local_path) == r.expected_hash:
+        if os.path.exists(r.pkg_path):
+            if util.sha1_file(r.pkg_path) == r.expected_hash:
                 cached_size += r.size
             else:
                 # partial download?
-                part_path = r.local_path + ".part"
+                part_path = r.pkg_path + ".part"
                 if os.path.exists(part_path):
                     cached_size += os.stat(part_path).st_size
 
@@ -152,15 +152,12 @@ def fetch_packages(order):
     items_to_fetch = []
 
     for r in resources:
-        if r.uri.is_remote_file():
-            # Check if it's already cached and valid
-            if (
-                os.path.exists(r.local_path)
-                and util.sha1_file(r.local_path) == r.expected_hash
-            ):
-                ctx.ui.info(_(f"{r.uri.filename()} [cached]"))
-                continue
+        # Check if it's already cached and valid
+        if os.path.exists(r.pkg_path) and util.sha1_file(r.pkg_path) == r.expected_hash:
+            ctx.ui.info(_(f"{r.uri.filename()} [cached]"))
+            continue
 
+        if r.uri.is_remote_file():
             items_to_fetch.append(r)
 
     if items_to_fetch:

--- a/pisi/operations/helper.py
+++ b/pisi/operations/helper.py
@@ -13,6 +13,7 @@ import pisi.ui as ui
 import pisi.util as util
 from pisi import Error
 from pisi import translate as _
+from pisi.fetcher import Fetcher
 
 
 def reorder_base_packages_old(order):
@@ -35,18 +36,20 @@ def reorder_base_packages_old(order):
         ctx.ui.info(_("install_order: %s" % install_order))
     return install_order
 
+
 def reorder_base_packages(order):
     """Dummy function that doesn't actually re-order system.base in front.
 
-       We now use OrderedSets, which keep the original topological sort,
-       so this shouldn't actually be necessary now.
+    We now use OrderedSets, which keep the original topological sort,
+    so this shouldn't actually be necessary now.
 
-       This also implies that the only function of system.base is for the
-       packages in it to be un-removable.
+    This also implies that the only function of system.base is for the
+    packages in it to be un-removable.
     """
     if len(order) > 1 and ctx.config.get_option("debug"):
         ctx.ui.info(_("order: %s" % order))
     return order
+
 
 def check_conflicts(order, packagedb):
     """check if upgrading to the latest versions will cause havoc
@@ -131,3 +134,36 @@ def calculate_download_sizes(order):
 
     ctx.ui.notify(ui.cached, total=total_size, cached=cached_size)
     return total_size, cached_size
+
+
+def get_download_info(order):
+    """
+    Returns a list of PackageResource objects for each package in order.
+    """
+    packagedb = pisi.db.packagedb.PackageDB()
+    return [packagedb.get_resource(name) for name in order]
+
+
+def fetch_packages(order):
+    """
+    Fetches all packages in order concurrently if they are not already cached.
+    """
+    resources = get_download_info(order)
+    items_to_fetch = []
+
+    for r in resources:
+        if r.uri.is_remote_file():
+            # Check if it's already cached and valid
+            if (
+                os.path.exists(r.local_path)
+                and util.sha1_file(r.local_path) == r.expected_hash
+            ):
+                continue
+
+            items_to_fetch.append(
+                (r.uri, os.path.dirname(r.local_path), r.uri.filename())
+            )
+
+    if items_to_fetch:
+        fetcher = Fetcher()
+        fetcher.fetch_multi(items_to_fetch)

--- a/pisi/operations/helper.py
+++ b/pisi/operations/helper.py
@@ -150,15 +150,28 @@ def fetch_packages(order):
     """
     resources = get_download_info(order)
     items_to_fetch = []
+    precached = []
 
     for r in resources:
         # Check if it's already cached and valid
         if os.path.exists(r.pkg_path) and util.sha1_file(r.pkg_path) == r.expected_hash:
-            ctx.ui.info(_(f"{r.uri.filename()} [cached]"))
+            precached.append(r)
             continue
 
         if r.uri.is_remote_file():
             items_to_fetch.append(r)
+
+    ctx.ui.info(
+        util.colorize(
+            _(
+                f"Downloading {len(items_to_fetch)} package resources ({len(precached)} cached)"
+            ),
+            "yellow",
+        )
+    )
+
+    for r in precached:
+        ctx.ui.info(_(f"{r.uri.filename()} [cached]"))
 
     if items_to_fetch:
         fetcher = Fetcher()

--- a/pisi/operations/helper.py
+++ b/pisi/operations/helper.py
@@ -13,7 +13,6 @@ import pisi.ui as ui
 import pisi.util as util
 from pisi import Error
 from pisi import translate as _
-from pisi.fetcher import Fetcher
 
 
 def reorder_base_packages_old(order):
@@ -174,5 +173,7 @@ def fetch_packages(order):
         ctx.ui.info(_(f"{r.uri.filename()} [cached]"))
 
     if items_to_fetch:
+        from pisi.fetcher import Fetcher
+
         fetcher = Fetcher()
         fetcher.fetch_multi(items_to_fetch)

--- a/pisi/operations/history.py
+++ b/pisi/operations/history.py
@@ -101,7 +101,6 @@ def fetch_remote_file(fetcher, package, errors):
         ctx.ui.info(pisi.util.colorize(_("%s could not be found") % (package), "red"))
         return False
 
-    # TODO(Evan): Validate
     if not os.path.exists(resource.local_path):
         try:
             fetcher.fetch(resource.uri, os.path.dirname(resource.local_path))
@@ -179,6 +178,7 @@ def takeback(operation):
     errors = []
     paths = []
     fetch_items = []
+    fetch_map = {}
 
     for pkg_name in beinstalled:
         pkg_file = pkg_name + ctx.const.package_suffix
@@ -193,6 +193,7 @@ def takeback(operation):
 
         if not os.path.exists(resource.local_path):
             fetch_items.append(resource)
+            fetch_map[resource] = pkg_name
         else:
             ctx.ui.info(_("%s [cached]") % resource.uri.filename())
             paths.append(resource.local_path)
@@ -201,11 +202,16 @@ def takeback(operation):
         ctx.ui.status(_("Downloading historical packages..."))
         try:
             fetcher.fetch_multi(fetch_items)
-            for resource in fetch_items:
-                paths.append(resource.local_path)
         except Exception as e:
             ctx.ui.error(_("Error while fetching historical packages: %s") % str(e))
-            # We might still have some packages, but maybe it's safer to stop or ask.
+
+        for resource in fetch_items:
+            if os.path.exists(resource.local_path):
+                paths.append(resource.local_path)
+            else:
+                pkg_name = fetch_map.get(resource, resource.name)
+                if pkg_name not in errors:
+                    errors.append(pkg_name)
 
     if errors:
         ctx.ui.info(

--- a/pisi/operations/history.py
+++ b/pisi/operations/history.py
@@ -4,7 +4,6 @@
 import os
 
 from ordered_set import OrderedSet as set
-from requests import HTTPError
 
 import pisi
 import pisi.context as ctx
@@ -12,7 +11,6 @@ import pisi.db
 import pisi.package
 import pisi.util
 from pisi import translate as _
-from pisi.fetcher import Fetcher
 
 
 class PackageNotFound(pisi.Error):
@@ -139,6 +137,8 @@ def plan_takeback(operation):
 def takeback(operation):
     historydb = pisi.db.historydb.HistoryDB()
     beinstalled, beremoved, configs = plan_takeback(operation)
+    from pisi.fetcher import Fetcher
+
     fetcher = Fetcher()
 
     if beinstalled:

--- a/pisi/operations/history.py
+++ b/pisi/operations/history.py
@@ -2,18 +2,16 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 import os
-import gettext
-
-__trans = gettext.translation("pisi", fallback=True)
-_ = __trans.gettext
 
 from ordered_set import OrderedSet as set
+from requests import HTTPError
 
 import pisi
 import pisi.context as ctx
-import pisi.util
 import pisi.db
-import pisi.fetcher
+import pisi.util
+from pisi import translate as _
+from pisi.fetcher import Fetcher
 
 
 class PackageNotFound(pisi.Error):
@@ -99,7 +97,7 @@ def __getpackageurl(package):
     return os.path.join(os.path.dirname(repourl), package)
 
 
-def fetch_remote_file(package, errors):
+def fetch_remote_file(fetcher, package, errors):
     try:
         uri = pisi.file.File.make_uri(__getpackageurl_binman(package))
     except PackageNotFound:
@@ -109,20 +107,18 @@ def fetch_remote_file(package, errors):
 
     dest = ctx.config.cached_packages_dir()
     filepath = os.path.join(dest, uri.filename())
+    # TODO(Evan): Validate
     if not os.path.exists(filepath):
-        failed = False
         try:
-            pisi.fetcher.fetch_url(uri, dest, ctx.ui.Progress)
-        except pisi.fetcher.FetchError as e:
-            failed = True
-        if failed:
+            fetcher.fetch(uri, dest)
+        except HTTPError | IOError | ValueError:
             try:
                 new_uri = pisi.file.File.make_uri(__getpackageurl(package))
-                pisi.fetcher.fetch_url(new_uri, dest, ctx.ui.Progress)
-            except:
+                fetcher.fetch(new_uri, dest)
+            except HTTPError | IOError | ValueError:
                 errors.append(package)
                 ctx.ui.info(
-                    pisi.util.colorize(_("%s could not be found") % (package), "red")
+                    pisi.util.colorize(_(f"{package} could not be found"), "red")
                 )
                 return False
     else:
@@ -176,6 +172,7 @@ def plan_takeback(operation):
 def takeback(operation):
     historydb = pisi.db.historydb.HistoryDB()
     beinstalled, beremoved, configs = plan_takeback(operation)
+    fetcher = Fetcher()
 
     if beinstalled:
         ctx.ui.info(
@@ -202,7 +199,7 @@ def takeback(operation):
             )
         )
         pkg += ctx.const.package_suffix
-        if fetch_remote_file(pkg, errors):
+        if fetch_remote_file(fetcher, pkg, errors):
             paths.append(os.path.join(ctx.config.cached_packages_dir(), pkg))
 
     if errors:

--- a/pisi/operations/history.py
+++ b/pisi/operations/history.py
@@ -190,17 +190,40 @@ def takeback(operation):
 
     errors = []
     paths = []
-    for pkg in beinstalled:
-        ctx.ui.info(
-            pisi.util.colorize(
-                _("Downloading %d / %d")
-                % (beinstalled.index(pkg) + 1, len(beinstalled)),
-                "yellow",
-            )
-        )
-        pkg += ctx.const.package_suffix
-        if fetch_remote_file(fetcher, pkg, errors):
-            paths.append(os.path.join(ctx.config.cached_packages_dir(), pkg))
+    fetch_items = []
+
+    for pkg_name in beinstalled:
+        pkg_file = pkg_name + ctx.const.package_suffix
+        try:
+            uri = pisi.file.File.make_uri(__getpackageurl_binman(pkg_file))
+        except PackageNotFound:
+            try:
+                uri = pisi.file.File.make_uri(__getpackageurl(pkg_file))
+            except PackageNotFound:
+                errors.append(pkg_name)
+                ctx.ui.info(
+                    pisi.util.colorize(_("%s could not be found") % (pkg_name), "red")
+                )
+                continue
+
+        dest = ctx.config.cached_packages_dir()
+        filepath = os.path.join(dest, uri.filename())
+
+        if not os.path.exists(filepath):
+            fetch_items.append((uri, dest, uri.filename()))
+        else:
+            ctx.ui.info(_("%s [cached]") % uri.filename())
+            paths.append(filepath)
+
+    if fetch_items:
+        ctx.ui.status(_("Downloading historical packages..."))
+        try:
+            fetcher.fetch_multi(fetch_items)
+            for item in fetch_items:
+                paths.append(os.path.join(item[1], item[2]))
+        except Exception as e:
+            ctx.ui.error(_("Error while fetching historical packages: %s") % str(e))
+            # We might still have some packages, but maybe it's safer to stop or ask.
 
     if errors:
         ctx.ui.info(

--- a/pisi/operations/history.py
+++ b/pisi/operations/history.py
@@ -9,6 +9,7 @@ from requests import HTTPError
 import pisi
 import pisi.context as ctx
 import pisi.db
+import pisi.package
 import pisi.util
 from pisi import translate as _
 from pisi.fetcher import Fetcher
@@ -47,82 +48,69 @@ def __listactions(actions):
     return beinstalled, beremoved, configs
 
 
-def __getpackageurl_binman(package):
+def __get_package_resource(package_file):
     packagedb = pisi.db.packagedb.PackageDB()
     repodb = pisi.db.repodb.RepoDB()
-    pkg, ver = pisi.util.parse_package_name(package)
+    pkg_name, _ver = pisi.util.parse_package_name(package_file)
 
     reponame = None
     try:
-        reponame = packagedb.which_repo(pkg)
+        reponame = packagedb.which_repo(pkg_name)
     except Exception:
-        # Maybe this package is obsoluted from repository
+        # Maybe this package is obsoleted from repository
         for repo in repodb.get_binary_repos():
-            if pkg in packagedb.get_obsoletes(repo):
+            if pkg_name in packagedb.get_obsoletes(repo):
                 reponame = repo
 
     if not reponame:
         raise PackageNotFound
 
-    package_ = packagedb.get_package(pkg)
     repourl = repodb.get_repo_url(reponame)
-    base_package = os.path.dirname(package_.packageURI)
     repo_base = os.path.dirname(repourl)
-    possible_url = os.path.join(repo_base, base_package, package)
-    ctx.ui.info(_("Package %s found in repository %s") % (pkg, reponame))
 
-    # return _possible_ url for this package
-    return possible_url
-
-
-def __getpackageurl(package):
-    packagedb = pisi.db.packagedb.PackageDB()
-    repodb = pisi.db.repodb.RepoDB()
-    pkg, ver = pisi.util.parse_package_name(package)
-
-    reponame = None
+    # Try binman style first
     try:
-        reponame = packagedb.which_repo(pkg)
+        package_ = packagedb.get_package(pkg_name)
+        base_package = os.path.dirname(package_.packageURI)
+        url = os.path.join(repo_base, base_package, package_file)
     except Exception:
-        # Maybe this package is obsoluted from repository
-        for repo in repodb.get_binary_repos():
-            if pkg in packagedb.get_obsoletes(repo):
-                reponame = repo
+        # Fallback to simple style
+        url = os.path.join(repo_base, package_file)
 
-    if not reponame:
-        raise PackageNotFound
+    ctx.ui.info(_("Package %s found in repository %s") % (pkg_name, reponame))
 
-    repourl = repodb.get_repo_url(reponame)
-    # return _possible_ url for this package
-    return os.path.join(os.path.dirname(repourl), package)
+    uri = pisi.file.File.make_uri(url)
+    dest = ctx.config.cached_packages_dir()
+    filepath = os.path.join(dest, uri.filename())
+
+    return pisi.package.PackageResource(
+        name=pkg_name,
+        uri=uri,
+        repo=reponame,
+        expected_hash=None,
+        size=None,
+        local_path=filepath,
+    )
 
 
 def fetch_remote_file(fetcher, package, errors):
     try:
-        uri = pisi.file.File.make_uri(__getpackageurl_binman(package))
+        resource = __get_package_resource(package)
     except PackageNotFound:
         errors.append(package)
         ctx.ui.info(pisi.util.colorize(_("%s could not be found") % (package), "red"))
         return False
 
-    dest = ctx.config.cached_packages_dir()
-    filepath = os.path.join(dest, uri.filename())
     # TODO(Evan): Validate
-    if not os.path.exists(filepath):
+    if not os.path.exists(resource.local_path):
         try:
-            fetcher.fetch(uri, dest)
-        except HTTPError | IOError | ValueError:
-            try:
-                new_uri = pisi.file.File.make_uri(__getpackageurl(package))
-                fetcher.fetch(new_uri, dest)
-            except HTTPError | IOError | ValueError:
-                errors.append(package)
-                ctx.ui.info(
-                    pisi.util.colorize(_(f"{package} could not be found"), "red")
-                )
-                return False
+            fetcher.fetch(resource.uri, os.path.dirname(resource.local_path))
+        except (HTTPError, IOError, ValueError):
+            errors.append(package)
+            ctx.ui.info(pisi.util.colorize(_(f"{package} could not be found"), "red"))
+            return False
     else:
-        ctx.ui.info(_("%s [cached]") % uri.filename())
+        ctx.ui.info(_("%s [cached]") % resource.uri.filename())
     return True
 
 
@@ -195,32 +183,26 @@ def takeback(operation):
     for pkg_name in beinstalled:
         pkg_file = pkg_name + ctx.const.package_suffix
         try:
-            uri = pisi.file.File.make_uri(__getpackageurl_binman(pkg_file))
+            resource = __get_package_resource(pkg_file)
         except PackageNotFound:
-            try:
-                uri = pisi.file.File.make_uri(__getpackageurl(pkg_file))
-            except PackageNotFound:
-                errors.append(pkg_name)
-                ctx.ui.info(
-                    pisi.util.colorize(_("%s could not be found") % (pkg_name), "red")
-                )
-                continue
+            errors.append(pkg_name)
+            ctx.ui.info(
+                pisi.util.colorize(_("%s could not be found") % (pkg_name), "red")
+            )
+            continue
 
-        dest = ctx.config.cached_packages_dir()
-        filepath = os.path.join(dest, uri.filename())
-
-        if not os.path.exists(filepath):
-            fetch_items.append((uri, dest, uri.filename()))
+        if not os.path.exists(resource.local_path):
+            fetch_items.append(resource)
         else:
-            ctx.ui.info(_("%s [cached]") % uri.filename())
-            paths.append(filepath)
+            ctx.ui.info(_("%s [cached]") % resource.uri.filename())
+            paths.append(resource.local_path)
 
     if fetch_items:
         ctx.ui.status(_("Downloading historical packages..."))
         try:
             fetcher.fetch_multi(fetch_items)
-            for item in fetch_items:
-                paths.append(os.path.join(item[1], item[2]))
+            for resource in fetch_items:
+                paths.append(resource.local_path)
         except Exception as e:
             ctx.ui.error(_("Error while fetching historical packages: %s") % str(e))
             # We might still have some packages, but maybe it's safer to stop or ask.

--- a/pisi/operations/history.py
+++ b/pisi/operations/history.py
@@ -93,26 +93,6 @@ def __get_package_resource(package_file):
     )
 
 
-def fetch_remote_file(fetcher, package, errors):
-    try:
-        resource = __get_package_resource(package)
-    except PackageNotFound:
-        errors.append(package)
-        ctx.ui.info(pisi.util.colorize(_("%s could not be found") % (package), "red"))
-        return False
-
-    if not os.path.exists(resource.local_path):
-        try:
-            fetcher.fetch(resource.uri, os.path.dirname(resource.local_path))
-        except (HTTPError, IOError, ValueError):
-            errors.append(package)
-            ctx.ui.info(pisi.util.colorize(_(f"{package} could not be found"), "red"))
-            return False
-    else:
-        ctx.ui.info(_("%s [cached]") % resource.uri.filename())
-    return True
-
-
 def get_snapshot_actions(operation):
     actions = {}
     snapshot_pkgs = set()

--- a/pisi/operations/install.py
+++ b/pisi/operations/install.py
@@ -134,12 +134,12 @@ def install_pkg_names(packages, reinstall=False):
     # Verify hashes and instantiate Install objects
     install_ops = []
     for r in resources:
-        if util.sha1_file(r.local_path) != r.expected_hash:
+        if util.sha1_file(r.pkg_path) != r.expected_hash:
             raise Error(
                 _("Download Error: Package %s does not match the repository package.")
                 % r.name
             )
-        install_ops.append(atomicoperations.Install(r.local_path))
+        install_ops.append(atomicoperations.Install(r.pkg_path))
 
     ctx.ui.status(_("Finished downloading packages."))
 

--- a/pisi/operations/install.py
+++ b/pisi/operations/install.py
@@ -7,21 +7,22 @@ import sys
 import zipfile
 
 from ordered_set import OrderedSet as set
-from pisi import translate as _
-from pisi import Error
 
 import pisi
-import pisi.context as ctx
-import pisi.util as util
 import pisi.atomicoperations as atomicoperations
+import pisi.context as ctx
+import pisi.db
 import pisi.operations as operations
 import pisi.pgraph as pgraph
 import pisi.signalhandler as signalhandler
 import pisi.ui as ui
-import pisi.db
+import pisi.util as util
+from pisi import Error
+from pisi import translate as _
 
-BASELAYOUT_PKG = 'baselayout'
-EOPKG_PKG = 'eopkg'
+BASELAYOUT_PKG = "baselayout"
+EOPKG_PKG = "eopkg"
+
 
 def plan_deterministic_install_order(order):
     """Ensure that baselayout is put at the end of any topological sort that includes it."""
@@ -37,6 +38,7 @@ def plan_deterministic_install_order(order):
 
     return order
 
+
 def install_pkg_names(packages, reinstall=False):
     """
     Installs packages from the repository.
@@ -50,13 +52,17 @@ def install_pkg_names(packages, reinstall=False):
     packagedb = pisi.db.packagedb.PackageDB()
     signal_handler = signalhandler.SignalHandler()
 
-    packages = [str(package) for package in packages]  # FIXME: why do we still get unicode input here? :/ -- exa
+    packages = [
+        str(package) for package in packages
+    ]  # FIXME: why do we still get unicode input here? :/ -- exa
 
     deduped_packages = packages = set(packages)
 
     # filter packages that are already installed
     if not reinstall:
-        not_installed = set([package for package in packages if not installdb.has_package(package)])
+        not_installed = set(
+            [package for package in packages if not installdb.has_package(package)]
+        )
         diff = packages - not_installed
         if len(diff) > 0:
             ctx.ui.warning(
@@ -119,16 +125,21 @@ def install_pkg_names(packages, reinstall=False):
 
     ctx.ui.notify(ui.packagestogo, order=order)
 
-    automatic = operations.helper.extract_automatic(packages, order)
-    paths = []
-    for package in order:
-        ctx.ui.info(
-            util.colorize(
-                _("Downloading %d / %d") % (order.index(package) + 1, len(order)), "yellow"
+    # Resolve resources
+    resources = operations.helper.get_download_info(order)
+
+    # Fetch packages concurrently
+    operations.helper.fetch_packages(order)
+
+    # Verify hashes and instantiate Install objects
+    install_ops = []
+    for r in resources:
+        if util.sha1_file(r.local_path) != r.expected_hash:
+            raise Error(
+                _("Download Error: Package %s does not match the repository package.")
+                % r.name
             )
-        )
-        install_op = atomicoperations.Install.from_name(package)
-        paths.append(install_op.package_fname)
+        install_ops.append(atomicoperations.Install(r.local_path))
 
     ctx.ui.status(_("Finished downloading packages."))
 
@@ -147,15 +158,16 @@ def install_pkg_names(packages, reinstall=False):
     ctx.ui.info(_("Disabling keyboard interrupts for file operations."))
     signal_handler.disable_signal(signal.SIGINT)
 
+    automatic = operations.helper.extract_automatic(packages, order)
+
     try:
-        for path in paths:
+        for i, install_op in enumerate(install_ops):
             ctx.ui.info(
                 util.colorize(
-                    _("Installing %d / %d") % (paths.index(path) + 1, len(paths)),
+                    _("Installing %d / %d") % (i + 1, len(install_ops)),
                     "yellow",
                 )
             )
-            install_op = atomicoperations.Install(path)
             if install_op.pkginfo.name in automatic:
                 install_op.automatic = True
             install_op.install(False)

--- a/pisi/operations/upgrade.py
+++ b/pisi/operations/upgrade.py
@@ -213,13 +213,13 @@ def upgrade(packages=[], repo=None):
     # Verify hashes and instantiate Install objects
     install_ops = []
     for r in resources:
-        if util.sha1_file(r.local_path) != r.expected_hash:
+        if util.sha1_file(r.pkg_path) != r.expected_hash:
             raise Error(
                 _("Download Error: Package %s does not match the repository package.")
                 % r.name
             )
         install_ops.append(
-            atomicoperations.Install(r.local_path, ignore_file_conflicts=True)
+            atomicoperations.Install(r.pkg_path, ignore_file_conflicts=True)
         )
 
     ctx.ui.status(_("Finished downloading package upgrades."))

--- a/pisi/operations/upgrade.py
+++ b/pisi/operations/upgrade.py
@@ -5,19 +5,19 @@ import signal
 import sys
 
 from ordered_set import OrderedSet as set
-from pisi import translate as _
-from pisi import Error
 
 import pisi
-import pisi.ui as ui
-import pisi.context as ctx
-import pisi.pgraph as pgraph
 import pisi.atomicoperations as atomicoperations
-import pisi.operations as operations
-import pisi.signalhandler as signalhandler
-import pisi.util as util
-import pisi.db
 import pisi.blacklist
+import pisi.context as ctx
+import pisi.db
+import pisi.operations as operations
+import pisi.pgraph as pgraph
+import pisi.signalhandler as signalhandler
+import pisi.ui as ui
+import pisi.util as util
+from pisi import Error
+from pisi import translate as _
 
 
 def check_update_actions(packages):
@@ -109,7 +109,7 @@ def find_upgrades(packages, replaces):
     return Ap
 
 
-def upgrade(packages = [], repo = None):
+def upgrade(packages=[], repo=None):
     """
     Re-installs packages from the repository, trying to perform
     a minimum or maximum number of upgrades according to options.
@@ -204,27 +204,34 @@ def upgrade(packages = [], repo = None):
 
     ctx.ui.notify(ui.packagestogo, order=order)
 
-    # Detect package conflicts
-    conflicts = []
-    if not ctx.get_option("ignore_package_conflicts"):
-        conflicts = operations.helper.check_conflicts(order, packagedb)
+    # Resolve resources
+    resources = operations.helper.get_download_info(order)
 
-    automatic = operations.helper.extract_automatic(packages, order)
-    paths = []
-    for x in order:
-        ctx.ui.info(
-            util.colorize(
-                _("Downloading %d / %d") % (order.index(x) + 1, len(order)), "yellow"
+    # Fetch packages concurrently
+    operations.helper.fetch_packages(order)
+
+    # Verify hashes and instantiate Install objects
+    install_ops = []
+    for r in resources:
+        if util.sha1_file(r.local_path) != r.expected_hash:
+            raise Error(
+                _("Download Error: Package %s does not match the repository package.")
+                % r.name
             )
+        install_ops.append(
+            atomicoperations.Install(r.local_path, ignore_file_conflicts=True)
         )
-        install_op = atomicoperations.Install.from_name(x)
-        paths.append(install_op.package_fname)
 
     ctx.ui.status(_("Finished downloading package upgrades."))
 
     # Don't actually install if --fetch-only was set
     if ctx.get_option("fetch_only"):
         return True
+
+    # Detect package conflicts
+    conflicts = []
+    if not ctx.get_option("ignore_package_conflicts"):
+        conflicts = operations.helper.check_conflicts(order, packagedb)
 
     # Handle package conflicts
     if conflicts:
@@ -236,15 +243,16 @@ def upgrade(packages = [], repo = None):
     ctx.ui.info(_("Disabling keyboard interrupts for file operations."))
     signal_handler.disable_signal(signal.SIGINT)
 
+    automatic = operations.helper.extract_automatic(packages, order)
+
     try:
-        for path in paths:
+        for i, install_op in enumerate(install_ops):
             ctx.ui.info(
                 util.colorize(
-                    _("Installing %d / %d") % (paths.index(path) + 1, len(paths)),
+                    _("Installing %d / %d") % (i + 1, len(install_ops)),
                     "yellow",
                 )
             )
-            install_op = atomicoperations.Install(path, ignore_file_conflicts=True)
             if install_op.pkginfo.name in automatic:
                 install_op.automatic = True
             install_op.install(True)
@@ -442,18 +450,32 @@ def upgrade_base(A=set()):
 
             if extra_upgrades:
                 ctx.ui.warning(
-                    _("Safety switch forces the upgrade of " "following packages:")
+                    _("Safety switch forces the upgrade of following packages:")
                 )
                 ctx.ui.info(util.format_by_columns(sorted(extra_upgrades)))
                 G_f, upgrade_order = plan_upgrade(extra_upgrades, force_replaced=False)
 
-             # return packages that must be added to any installation
+            # return packages that must be added to any installation
             install_and_upgrade_order = set(install_order + upgrade_order)
             if len(install_and_upgrade_order) > 1 and ctx.config.get_option("debug"):
-                ctx.ui.info(_("installs and upgrades (unordered): %s" % install_and_upgrade_order))
-            install_and_upgrade_order = operations.install.plan_deterministic_install_order(install_and_upgrade_order)
+                ctx.ui.info(
+                    _(
+                        "installs and upgrades (unordered): %s"
+                        % install_and_upgrade_order
+                    )
+                )
+            install_and_upgrade_order = (
+                operations.install.plan_deterministic_install_order(
+                    install_and_upgrade_order
+                )
+            )
             if len(install_and_upgrade_order) > 1 and ctx.config.get_option("debug"):
-                ctx.ui.info(_("installs and upgrades (deterministic order): %s" % install_and_upgrade_order))
+                ctx.ui.info(
+                    _(
+                        "installs and upgrades (deterministic order): %s"
+                        % install_and_upgrade_order
+                    )
+                )
             return install_and_upgrade_order
         else:
             ctx.ui.warning(

--- a/pisi/package.py
+++ b/pisi/package.py
@@ -5,16 +5,16 @@
 
 import os.path
 
-from pisi import translate as _
-
 import pisi
-import pisi.context as ctx
 import pisi.archive as archive
-import pisi.uri
-import pisi.metadata
+import pisi.context as ctx
 import pisi.file
 import pisi.files
+import pisi.metadata
+import pisi.uri
 import pisi.util as util
+from pisi import translate as _
+
 from . import fetcher
 
 
@@ -33,6 +33,12 @@ class PackageResource:
         self.size = size
         self.local_path = local_path
         self.is_delta = is_delta
+
+    @property
+    def pkg_path(self):
+        # If installing from a local repository eopkg will just directly install
+        # the package instead of installing from the cached archive
+        return self.local_path if self.uri.is_remote_file() else self.uri.path()
 
 
 class Package:

--- a/pisi/package.py
+++ b/pisi/package.py
@@ -8,14 +8,11 @@ import os.path
 import pisi
 import pisi.archive as archive
 import pisi.context as ctx
-import pisi.file
 import pisi.files
 import pisi.metadata
 import pisi.uri
 import pisi.util as util
 from pisi import translate as _
-
-from . import fetcher
 
 
 class Error(pisi.Error):

--- a/pisi/signalhandler.py
+++ b/pisi/signalhandler.py
@@ -14,6 +14,8 @@ class SignalWrapper:
     Attributes:
         signal (signal.Signals): The signal being wrapped.
         old_handler (signal.Handlers): The original signal handler.
+        ref_count (int): The number of times this signal has been
+            disabled or caught.
     """
 
     def __init__(self, sig: signal.Signals):
@@ -25,6 +27,7 @@ class SignalWrapper:
         """
         self.signal = sig
         self.old_handler: signal.Handlers | None = signal.SIG_DFL
+        self.ref_count = 0
 
 
 class SignalHandler:
@@ -99,6 +102,7 @@ class SignalHandler:
             wrapper = SignalWrapper(sig)
             wrapper.old_handler = signal.signal(sig, signal.SIG_IGN)
             self.signals[sig] = wrapper
+        self.signals[sig].ref_count += 1
 
     def enable_signal(self, sig: signal.Signals):
         """
@@ -115,6 +119,8 @@ class SignalHandler:
             return
 
         wrapper = self.signals[sig]
+        wrapper.ref_count -= 1
 
-        signal.signal(sig, wrapper.old_handler)
-        del self.signals[sig]
+        if wrapper.ref_count <= 0:
+            signal.signal(sig, wrapper.old_handler)
+            del self.signals[sig]

--- a/pisi/signalhandler.py
+++ b/pisi/signalhandler.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 import signal
+import threading
+from threading import Event
 
 
 class SignalWrapper:
@@ -34,11 +36,53 @@ class SignalHandler:
     Attributes:
         signals (dict[signal.Signals, SignalWrapper]): Disabled signals
             and their handlers.
+        done_event (Event): An event that is set when a caught signal
+            is received.
     """
 
     def __init__(self):
         """Create a new SignalHandler instance."""
         self.signals: dict[signal.Signals, SignalWrapper] = {}
+        self.done_event = Event()
+
+    def handle_signal(self, signum, frame):
+        """
+        Internal signal handler that sets the done_event.
+        """
+        self.done_event.set()
+        if threading.current_thread() is threading.main_thread():
+            raise KeyboardInterrupt
+
+    def clear_event(self):
+        """
+        Clears the done_event.
+        """
+        self.done_event.clear()
+
+    def check_signals(self):
+        """
+        Checks if a signal was caught and raises KeyboardInterrupt if so.
+        """
+        if self.done_event.is_set():
+            self.clear_event()
+            raise KeyboardInterrupt
+
+    def catch_signal(self, sig: signal.Signals):
+        """
+        Catches a system signal by setting the handler to our own signal
+        handler, which sets the done_event.
+
+        Parameters:
+            sig (signal.Signals): The signal to catch.
+        """
+        if threading.current_thread() is not threading.main_thread():
+            return
+
+        if sig not in self.signals:
+            wrapper = SignalWrapper(sig)
+            wrapper.old_handler = signal.signal(sig, self.handle_signal)
+            self.signals[sig] = wrapper
+        self.signals[sig].ref_count += 1
 
     def disable_signal(self, sig: signal.Signals):
         """
@@ -48,6 +92,9 @@ class SignalHandler:
         Parameters:
             sig (signal.Signals): The signal to disable.
         """
+        if threading.current_thread() is not threading.main_thread():
+            return
+
         if sig not in self.signals:
             wrapper = SignalWrapper(sig)
             wrapper.old_handler = signal.signal(sig, signal.SIG_IGN)
@@ -61,7 +108,10 @@ class SignalHandler:
         Parameters:
             sig (signal.Signals): The signal to enable.
         """
-        if not sig in self.signals:
+        if threading.current_thread() is not threading.main_thread():
+            return
+
+        if sig not in self.signals:
             return
 
         wrapper = self.signals[sig]

--- a/pisi/sourcearchive.py
+++ b/pisi/sourcearchive.py
@@ -5,8 +5,6 @@
 
 import os
 
-from requests import HTTPError
-
 # pisi modules
 import pisi
 import pisi.archive
@@ -15,7 +13,6 @@ import pisi.mirrors
 import pisi.uri
 import pisi.util as util
 from pisi import translate as _
-from pisi.fetcher import Fetcher
 
 
 class Error(pisi.Error):
@@ -71,6 +68,10 @@ class SourceArchive:
             )
 
     def fetch_from_mirror(self):
+        from requests import HTTPError
+
+        from pisi.fetcher import Fetcher
+
         uri = self.url.get_uri()
         sep = uri[len("mirrors://") :].split("/")
         name = sep.pop(0)

--- a/pisi/sourcearchive.py
+++ b/pisi/sourcearchive.py
@@ -70,7 +70,6 @@ class SourceArchive:
                 % (ctx.config.archives_dir(), self.url.filename())
             )
 
-    # TODO(Evan): WTF
     def fetch_from_mirror(self):
         uri = self.url.get_uri()
         sep = uri[len("mirrors://") :].split("/")

--- a/pisi/sourcearchive.py
+++ b/pisi/sourcearchive.py
@@ -4,16 +4,18 @@
 # python standard library
 
 import os
-from pisi import translate as _
+
+from requests import HTTPError
 
 # pisi modules
 import pisi
-import pisi.util as util
-import pisi.context as ctx
 import pisi.archive
-import pisi.uri
-import pisi.fetcher
+import pisi.context as ctx
 import pisi.mirrors
+import pisi.uri
+import pisi.util as util
+from pisi import translate as _
+from pisi.fetcher import Fetcher
 
 
 class Error(pisi.Error):
@@ -68,11 +70,13 @@ class SourceArchive:
                 % (ctx.config.archives_dir(), self.url.filename())
             )
 
+    # TODO(Evan): WTF
     def fetch_from_mirror(self):
         uri = self.url.get_uri()
         sep = uri[len("mirrors://") :].split("/")
         name = sep.pop(0)
         archive = "/".join(sep)
+        fetcher = Fetcher()
 
         mirrors = pisi.mirrors.Mirrors().get_mirrors(name)
         if not mirrors:
@@ -82,14 +86,12 @@ class SourceArchive:
             try:
                 url = os.path.join(mirror, archive)
                 ctx.ui.warning(_("Fetching source from mirror: %s") % url)
-                pisi.fetcher.fetch_url(url, ctx.config.archives_dir(), self.progress)
+                fetcher.fetch(url, ctx.config.archives_dir())
                 return
-            except pisi.fetcher.FetchError:
+            except HTTPError | IOError | ValueError:
                 pass
 
-        raise pisi.fetcher.FetchError(
-            _("Could not fetch source from %s mirrors.") % name
-        )
+        raise Error(_(f"Could not fetch source from {name} mirrors."))
 
     def is_cached(self, interactive=True):
         if not os.access(self.archiveFile, os.R_OK):

--- a/pisi/util.py
+++ b/pisi/util.py
@@ -900,7 +900,11 @@ def filter_latest_packages(package_paths):
 def colorize(msg, color):
     """Colorize the given message for console output"""
     if color in ctx.const.colors and not ctx.get_option("no_color"):
-        return ctx.const.colors[color] + msg + ctx.const.colors["default"]
+        stripped = msg.rstrip("\n")
+        newlines = msg[len(stripped) :]
+        return (
+            ctx.const.colors[color] + stripped + ctx.const.colors["default"] + newlines
+        )
     else:
         return msg
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [{ name = "Solus Project", email = "releng@getsol.us" }]
 keywords = ["package", "manager", "management", "solus"]
 classifiers = ["Programming Language :: Python :: 3 :: Only"]
 requires-python = ">=3.8.0"
-dependencies = ["iksemel>=1.6.1", "lzma-mt>=0.1.4", "ordered_set>=4.1.0,<=4.2.0", "python-magic>=0.4.27", "requests>=2.32.0", "tqdm>=4.67.0", "xattr>= 1.1.0"]
+dependencies = ["iksemel>=1.6.1", "lzma-mt>=0.1.4", "ordered_set>=4.1.0,<=4.2.0", "python-magic>=0.4.27", "requests>=2.32.0", "rich>=13.0.0", "xattr>= 1.1.0"]
 dynamic = ["version"]
 
 [project.urls]
@@ -22,7 +22,7 @@ uneopkg = "pisi.scripts.uneopkg:main"
 # Builder-specific keys below. We use setuptools.
 
 [build-system]
-requires = ["setuptools>=58.0", "iksemel>=1.6.1", "lzma-mt>=0.1.4", "python-magic>=0.4.27", "ordered_set>=4.1.0,<=4.2.0", "requests>=2.32.0", "tqdm>=4.67.0"]
+requires = ["setuptools>=58.0", "iksemel>=1.6.1", "lzma-mt>=0.1.4", "python-magic>=0.4.27", "ordered_set>=4.1.0,<=4.2.0", "requests>=2.32.0", "rich>=13.0.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.dynamic]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [{ name = "Solus Project", email = "releng@getsol.us" }]
 keywords = ["package", "manager", "management", "solus"]
 classifiers = ["Programming Language :: Python :: 3 :: Only"]
 requires-python = ">=3.8.0"
-dependencies = ["iksemel>=1.6.1", "lzma-mt>=0.1.4", "ordered_set>=4.1.0,<=4.2.0", "python-magic>=0.4.27", "xattr>= 1.1.0"]
+dependencies = ["iksemel>=1.6.1", "lzma-mt>=0.1.4", "ordered_set>=4.1.0,<=4.2.0", "python-magic>=0.4.27", "requests>=2.32.0", "tqdm>=4.67.0", "xattr>= 1.1.0"]
 dynamic = ["version"]
 
 [project.urls]
@@ -22,7 +22,7 @@ uneopkg = "pisi.scripts.uneopkg:main"
 # Builder-specific keys below. We use setuptools.
 
 [build-system]
-requires = ["setuptools>=58.0", "iksemel>=1.6.1", "lzma-mt>=0.1.4", "python-magic>=0.4.27", "ordered_set>=4.1.0,<=4.2.0"]
+requires = ["setuptools>=58.0", "iksemel>=1.6.1", "lzma-mt>=0.1.4", "python-magic>=0.4.27", "ordered_set>=4.1.0,<=4.2.0", "requests>=2.32.0", "tqdm>=4.67.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.dynamic]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,6 @@ jeepney
 lzma_mt
 ordered_set
 python-magic
+requests
+tqdm
 xattr

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ lzma_mt
 ordered_set
 python-magic
 requests
-tqdm
+rich
 xattr


### PR DESCRIPTION
## Summary

Switches fetcher to use requests for downloading and rich for the progress bars
Adds a `fetch_multi()` method to download multiple packages concurrently
Changes various eopkg operations to use `fetch_multi()` for concurrent downloads

## TODO

- Takeback needs testing against obsolete packages (how?)

## Test Plan

Create a new rootfs and install system.base, system.devel as well as random packages to it
Fetch single package
Fetch multiple packages
Nuke cache then takeback to a state
Install package from a local repo
Fetch packages from local repo and remote repo
Do the python 3.14 rebuilds against this branch