### PR TITLE
atomicops: Restore previous package download printing behaviour

### DIFF
--- a/pisi/atomicoperations.py
+++ b/pisi/atomicoperations.py
@@ -77,6 +77,7 @@ class Install(AtomicOperation):
             if os.path.exists(resource.local_path):
                 if util.sha1_file(resource.local_path) != resource.expected_hash:
                     os.unlink(resource.local_path)
+                ctx.ui.info(_(f"{resource.uri.filename()} [cached]"))
             else:
                 # Explicitly download if not cached.
                 # Note: In the future, this should be handled by a separate fetch stage.

--- a/pisi/atomicoperations.py
+++ b/pisi/atomicoperations.py
@@ -70,7 +70,7 @@ class Install(AtomicOperation):
         packagedb = pisi.db.packagedb.PackageDB()
         resource = packagedb.get_resource(name)
 
-        ctx.ui.info(_(f"Package {name} found in repository"))
+        ctx.ui.info(_(f"Package {name} found in repository {resource.repo}"))
         ctx.ui.info(_(f"Package URI: {resource.uri}"), verbose=True)
 
         if resource.uri.is_remote_file():


### PR DESCRIPTION
## Summary

There were a couple of small oversights after 44a8d88, restore the previous printing behavior

## Test Plan

Verify the printing behavior matches from before