### PR TITLE
filesdb: Update to use sqlite3 for py3.13

### DIFF
--- a/pisi/db/filesdb.py
+++ b/pisi/db/filesdb.py
@@ -22,13 +22,21 @@ from pisi.db import lazydb
 # file conflict mechanism of pisi prevents this and needs a fast has_file function.
 # So currently filesdb is the only db and we cant still get rid of rebuild-db :/
 
-# This MUST match the version used in eopkg.py2 as long as that is in use.
+# This MUST match the version used in eopkg.py2 (2) as long as that is in use.
 # Now that eopkg.py2 is no longer in use, just use the current default version.
 FILESDB_PICKLE_PROTOCOL_VERSION = pickle.DEFAULT_PROTOCOL
 
-# We suspect that there will be an advantage in versioning this separately
-# As long as a gdbm-backed shelve is used, no need to bump this beyond 4
-FILESDB_FORMAT_VERSION = 4
+# We suspect that there will be an advantage in versioning this separately.
+# As long as a gdbm-backed shelve is used, no need to bump this beyond 4.
+# For py3.13 and up, bump this to 5 and use sqlite3 instead (the default in py3.13).
+# Context: dbm shelves are preferentially opened in a specific order, if the
+#          relevant db module is available on the system, and CPython was compiled
+#          with it:
+#          - dbm.sqlite3 (only py3.13 and up)
+#          - dbm.gnu (gdbm in py2)
+#          - dbm.ndbm
+#          - dbm.dumbdb
+FILESDB_FORMAT_VERSION = 5
 
 class FilesDB(lazydb.LazyDB):
     def init(self, force_rebuild=False):
@@ -117,7 +125,7 @@ class FilesDB(lazydb.LazyDB):
         #     => ignore, don't rebuild
         # file exists:
         #   can write:
-        #     type == gdbm:
+        #     type == sqlite3:
         #       version match:
         #         => open flag "w", don't rebuild
         #       else:
@@ -125,7 +133,7 @@ class FilesDB(lazydb.LazyDB):
         #     else:
         #       => open flag "n" (rebuild)
         #   cannot write:
-        #     type == gdbm:
+        #     type == sqlite3:
         #       version match:
         #         => open flag "r", don't rebuild
         #       else:
@@ -195,19 +203,19 @@ class FilesDB(lazydb.LazyDB):
             if os.access(files_db, os.W_OK):
                 can_write = True
                 # we need dbm.gnu here for success
-                if db_type != "dbm.gnu":
+                if db_type != "dbm.sqlite3":
                     if verbose:
                         ctx.ui.info(_("FilesDB %s is writable, but is of wrong type '%s'.") % (files_db, db_type))
                     flag = "n"
                     needs_rebuild = True
                 else:
                     flag = "w"
-                    # db_type is dbm.gnu and the backing file looks to be writable
+                    # db_type is dbm.sqlite3 and the backing file looks to be writable
                     # So far, so good
             elif os.access(files_db, os.R_OK):
                 can_write = False
-                # we need dbm.gnu here for success
-                if db_type != "dbm.gnu":
+                # we need dbm.sqlite3 here for success
+                if db_type != "dbm.sqlite3":
                     if verbose:
                         ctx.ui.info(_("FilesDB %s is readable, but is of wrong type '%s'.") % (files_db, db_type))
                     please_rebuild_manually = True
@@ -215,7 +223,7 @@ class FilesDB(lazydb.LazyDB):
                     if verbose:
                         ctx.ui.info(_("Cannot open FilesDB %s for writing. Opening it read-only.") % files_db)
                     flag = "r"
-                    # db_type is dbm.gnu and the backing file looks to be readable.
+                    # db_type is dbm.sqlite3 and the backing file looks to be readable.
                 # This block falls back to simple XML search if FilesDB is not the correct format
             else:
                 can_write = False


### PR DESCRIPTION
## Summary

For py3.13 and up, bump the format version to 5, and use sqlite3 instead (the default in py3.13).

The context is that dbm shelves are preferentially opened in a specific db format order if the relevant db module is available on the system, and CPython was compiled with support for said db module:

- dbm.sqlite3 (only py3.13 and up)
- dbm.gnu (gdbm in py2)
- dbm.ndbm
- dbm.dumbdb

## Test Plan

<img width="2373" height="372" alt="image" src="https://github.com/user-attachments/assets/7c6d8eed-3bd8-4e0c-96ef-df648828dfdb" />
