### PR TITLE
Refactor FilesDB checks & default to gdm.gnu shelve

### DIFF
--- a/pisi/db/filesdb.py
+++ b/pisi/db/filesdb.py
@@ -4,14 +4,13 @@
 import dbm
 import hashlib
 import os
-import pickle
 import re
 import shelve
 import sys
 
 import pisi
 from pisi import context as ctx
-from pisi import ngettext, util
+from pisi import ngettext
 from pisi import translate as _
 from pisi.db import lazydb
 

--- a/pisi/db/filesdb.py
+++ b/pisi/db/filesdb.py
@@ -21,21 +21,16 @@ from pisi.db import lazydb
 # file conflict mechanism of pisi prevents this and needs a fast has_file function.
 # So currently filesdb is the only db and we cant still get rid of rebuild-db :/
 
-# This MUST match the version used in eopkg.py2 (2) as long as that is in use.
-# Now that eopkg.py2 is no longer in use, just use the current default version.
-FILESDB_PICKLE_PROTOCOL_VERSION = pickle.DEFAULT_PROTOCOL
+# dbm.sqlite3 (default in py3.13+) is significantly slower for many small writes.
+# We literally just use the shelve as a fast file lookup
+try:
+    import dbm.gnu as gdbm
+except ImportError:
+    gdbm = None
 
-# We suspect that there will be an advantage in versioning this separately.
-# As long as a gdbm-backed shelve is used, no need to bump this beyond 4.
-# For py3.13 and up, bump this to 5 and use sqlite3 instead (the default in py3.13).
-# Context: dbm shelves are preferentially opened in a specific order, if the
-#          relevant db module is available on the system, and CPython was compiled
-#          with it:
-#          - dbm.sqlite3 (only py3.13 and up)
-#          - dbm.gnu (gdbm in py2)
-#          - dbm.ndbm
-#          - dbm.dumbdb
-if sys.version_info >= (3, 13):
+if gdbm:
+    FILESDB_FORMAT_VERSION = 4
+elif sys.version_info >= (3, 13):
     FILESDB_FORMAT_VERSION = 5
 else:
     FILESDB_FORMAT_VERSION = 4
@@ -108,48 +103,51 @@ class FilesDB(lazydb.LazyDB):
             os.unlink(files_db)
 
     def close(self):
-        if isinstance(self.filesdb, shelve.DbfilenameShelf):
+        if isinstance(self.filesdb, shelve.Shelf):
             self.filesdb.sync()
             self.filesdb.close()
+
+    def __open_shelve(self, path, flag):
+        """Helper to open shelve with preferred backend."""
+        if gdbm:
+            try:
+                # Explicitly use gdbm if available for write performance
+                return shelve.Shelf(gdbm.open(path, flag))
+            except dbm.error:
+                # If it's not a gdbm file (e.g. it's sqlite), fall back to default
+                pass
+        return shelve.open(path, flag)
 
     def __check_filesdb(self, force_rebuild=False):
         """Sets valid self.files_db reference and automatically rebuilds the underlying db if necessary."""
 
         # already initialized
-        if isinstance(self.filesdb, shelve.DbfilenameShelf):
+        if isinstance(self.filesdb, shelve.Shelf):
             return
 
         files_db = os.path.join(ctx.config.info_dir(), ctx.const.files_db)
         needs_rebuild = force_rebuild
-        verbose = ctx.config.options.verbose
 
         if not force_rebuild:
             if os.path.exists(files_db):
                 try:
                     # Try opening read-write first
                     try:
-                        self.filesdb = shelve.open(
-                            files_db, "w", protocol=FILESDB_PICKLE_PROTOCOL_VERSION
-                        )
-                    except (dbm.error, PermissionError):
+                        self.filesdb = self.__open_shelve(files_db, "w")
+                    except dbm.error:
                         # Fallback to read-only
-                        self.filesdb = shelve.open(
-                            files_db, "r", protocol=FILESDB_PICKLE_PROTOCOL_VERSION
-                        )
-                        if verbose:
-                            ctx.ui.info(_("Opened FilesDB %s read-only.") % files_db)
+                        self.filesdb = self.__open_shelve(files_db, "r")
+                        ctx.ui.debug(_("Opened FilesDB %s read-only.") % files_db)
 
                     # Check version
                     if self.filesdb.get("version") != FILESDB_FORMAT_VERSION:
-                        if verbose:
-                            ctx.ui.info(
-                                _("FilesDB version mismatch or missing version.")
-                            )
+                        ctx.ui.warning(
+                            _("FilesDB version mismatch or missing version.")
+                        )
                         needs_rebuild = True
 
                 except Exception as e:
-                    if verbose:
-                        ctx.ui.debug(f"Failed to open FilesDB {files_db}: {e}")
+                    ctx.ui.debug(f"Failed to open FilesDB {files_db}: {e}")
                     needs_rebuild = True
             else:
                 # File missing
@@ -160,6 +158,8 @@ class FilesDB(lazydb.LazyDB):
             if os.access(os.path.dirname(files_db) or ".", os.W_OK):
                 self.__rebuild()
             else:
+                self.close()
+                self.filesdb = {}
                 ctx.ui.warning(
                     _("FilesDB is invalid and cannot be rebuilt (no write access).")
                 )
@@ -176,9 +176,7 @@ class FilesDB(lazydb.LazyDB):
 
         try:
             # "n" means we're opening a new shelve, overwriting the old one
-            self.filesdb = shelve.open(
-                files_db, "n", protocol=FILESDB_PICKLE_PROTOCOL_VERSION
-            )
+            self.filesdb = self.__open_shelve(files_db, "n")
         except Exception as err:
             ctx.ui.error(_("FilesDB rebuild failed: %s") % err)
             raise err

--- a/pisi/db/filesdb.py
+++ b/pisi/db/filesdb.py
@@ -137,17 +137,24 @@ class FilesDB(lazydb.LazyDB):
                     except dbm.error:
                         # Fallback to read-only
                         self.filesdb = self.__open_shelve(files_db, "r")
-                        ctx.ui.debug(_("Opened FilesDB %s read-only.") % files_db)
+                        ctx.ui.debug(
+                            # . FilesDB is a proper name and should not be translated
+                            _(f"Opened FilesDB {files_db} read-only.")
+                        )
 
                     # Check version
                     if self.filesdb.get("version") != FILESDB_FORMAT_VERSION:
                         ctx.ui.warning(
+                            # . FilesDB is a proper name and should not be translated
                             _("FilesDB version mismatch or missing version.")
                         )
                         needs_rebuild = True
 
                 except Exception as e:
-                    ctx.ui.debug(f"Failed to open FilesDB {files_db}: {e}")
+                    ctx.ui.debug(
+                        # . FilesDB is a proper name and should not be translated
+                        _(f"Failed to open FilesDB {files_db}: {e}")
+                    )
                     needs_rebuild = True
             else:
                 # File missing
@@ -161,6 +168,7 @@ class FilesDB(lazydb.LazyDB):
                 self.close()
                 self.filesdb = {}
                 ctx.ui.warning(
+                    # . FilesDB is a proper name and should not be translated
                     _("FilesDB is invalid and cannot be rebuilt (no write access).")
                 )
                 ctx.ui.warning(_("Falling back to slow and inaccurate XML search..."))
@@ -168,7 +176,10 @@ class FilesDB(lazydb.LazyDB):
     def __rebuild(self):
         # This assumes that __check_filesdb() has determined a rebuild is needed
         files_db = os.path.join(ctx.config.info_dir(), ctx.const.files_db)
-        ctx.ui.info(_("Rebuilding the FilesDB..."))
+        ctx.ui.info(
+            # . FilesDB is a proper name and should not be translated
+            _("Rebuilding the FilesDB...")
+        )
 
         self.close()
         self.destroy()
@@ -178,7 +189,10 @@ class FilesDB(lazydb.LazyDB):
             # "n" means we're opening a new shelve, overwriting the old one
             self.filesdb = self.__open_shelve(files_db, "n")
         except Exception as err:
-            ctx.ui.error(_("FilesDB rebuild failed: %s") % err)
+            ctx.ui.error(
+                # . FilesDB is a proper name and should not be translated
+                _("FilesDB rebuild failed: %s") % err
+            )
             raise err
 
         self.filesdb["version"] = FILESDB_FORMAT_VERSION
@@ -186,7 +200,10 @@ class FilesDB(lazydb.LazyDB):
         installdb = pisi.db.installdb.InstallDB()
         pkgs = 0
         verbose = ctx.config.options.verbose
-        ctx.ui.info(_("Adding packages to FilesDB %s:") % files_db)
+        ctx.ui.info(
+            # . FilesDB is a proper name and should not be translated
+            _(f"Adding packages to FilesDB {files_db}:")
+        )
         for pkg in installdb.list_installed():
             files = installdb.get_files(pkg)
             if verbose:
@@ -215,5 +232,6 @@ class FilesDB(lazydb.LazyDB):
         self.filesdb.sync()
         # This acts as a check that the version has been correctly added and synced to disk
         ctx.ui.info(
-            _("Done rebuilding FilesDB (version: %s)") % self.filesdb["version"]
+            # . FilesDB is a proper name and should not be translated
+            _(f"Finished rebuilding FilesDB (version: {self.filesdb['version']})")
         )

--- a/pisi/db/filesdb.py
+++ b/pisi/db/filesdb.py
@@ -7,13 +7,12 @@ import os
 import pickle
 import re
 import shelve
-
-from pisi import translate as _
-from pisi import ngettext
+import sys
 
 import pisi
 from pisi import context as ctx
-from pisi import util
+from pisi import ngettext, util
+from pisi import translate as _
 from pisi.db import lazydb
 
 # FIXME:
@@ -22,13 +21,25 @@ from pisi.db import lazydb
 # file conflict mechanism of pisi prevents this and needs a fast has_file function.
 # So currently filesdb is the only db and we cant still get rid of rebuild-db :/
 
-# This MUST match the version used in eopkg.py2 as long as that is in use.
+# This MUST match the version used in eopkg.py2 (2) as long as that is in use.
 # Now that eopkg.py2 is no longer in use, just use the current default version.
 FILESDB_PICKLE_PROTOCOL_VERSION = pickle.DEFAULT_PROTOCOL
 
-# We suspect that there will be an advantage in versioning this separately
-# As long as a gdbm-backed shelve is used, no need to bump this beyond 4
-FILESDB_FORMAT_VERSION = 4
+# We suspect that there will be an advantage in versioning this separately.
+# As long as a gdbm-backed shelve is used, no need to bump this beyond 4.
+# For py3.13 and up, bump this to 5 and use sqlite3 instead (the default in py3.13).
+# Context: dbm shelves are preferentially opened in a specific order, if the
+#          relevant db module is available on the system, and CPython was compiled
+#          with it:
+#          - dbm.sqlite3 (only py3.13 and up)
+#          - dbm.gnu (gdbm in py2)
+#          - dbm.ndbm
+#          - dbm.dumbdb
+if sys.version_info >= (3, 13):
+    FILESDB_FORMAT_VERSION = 5
+else:
+    FILESDB_FORMAT_VERSION = 4
+
 
 class FilesDB(lazydb.LazyDB):
     def init(self, force_rebuild=False):
@@ -104,219 +115,72 @@ class FilesDB(lazydb.LazyDB):
     def __check_filesdb(self, force_rebuild=False):
         """Sets valid self.files_db reference and automatically rebuilds the underlying db if necessary."""
 
-        # the db has already been correctly initialised and doesn't need a rebuild
+        # already initialized
         if isinstance(self.filesdb, shelve.DbfilenameShelf):
             return
 
-        # Valid states:
-        #
-        # file does not exist:
-        #   can write
-        #     => open flag "n" (rebuild)
-        #   cannot write
-        #     => ignore, don't rebuild
-        # file exists:
-        #   can write:
-        #     type == gdbm:
-        #       version match:
-        #         => open flag "w", don't rebuild
-        #       else:
-        #         => open flag "n" (rebuild)
-        #     else:
-        #       => open flag "n" (rebuild)
-        #   cannot write:
-        #     type == gdbm:
-        #       version match:
-        #         => open flag "r", don't rebuild
-        #       else:
-        #         => ignore, don't rebuild
-        #     else:
-        #       => ignore, don't rebuild
-
-        # Does the FilesDB filename exist?
-        file_exists = None
-        # Can we write to the file?
-        can_write = None
-        # Which type is the db?
-        db_type = None
-        # Which access rights do we open the shelve with?
-        # Note that flag = "n" is equivalent to "rebuild"
-        flag = None
-        # Can we read the shelve?
-        valid_shelve = None
-        # Does the FilesDB have a version?
-        version = None
-        # Do we need to rebuild the FilesDB?
-        needs_rebuild = None
-        # Do we need to display a reminder to rebuild FilesDB manually?
-        please_rebuild_manually = None
-        # Has the user asked for verbose output
+        files_db = os.path.join(ctx.config.info_dir(), ctx.const.files_db)
+        needs_rebuild = force_rebuild
         verbose = ctx.config.options.verbose
 
-        files_db = os.path.join(ctx.config.info_dir(), ctx.const.files_db)
-
-        # The goal of this large block is to deduce the flags with which to
-        # open the FilesDB shelve.
-        #
-        # The "best" paths are the one where 'flag' is set and where neither
-        # 'needs_rebuild' nor 'please_rebuild_manually' are True.
-        #
-        # Any path that results in needs_rebuild being set to True will
-        # auto-rebuild the db.
-        # 
-        # All other paths imply that something is wrong with the FilesDB,
-        # which in turn implies falling back to slow XML access for searches.
-        #
-        if not os.path.exists(files_db):
-            msg = _("FilesDB %s does not exist.") % files_db
-            file_exists = False
-            try:
-                with open(files_db, "w") as fp:
-                    pass
-                os.unlink(files_db)
-                can_write = True
-                flag = "n"
-                if verbose:
-                    ctx.ui.info(msg)
-                needs_rebuild = True
-            except:
-                can_write = False
-                if verbose:
-                    ctx.ui.warning(msg)
-                please_rebuild_manually = True
-                # This block falls back to simple XML search because FilesDB is missing.
-        # path exists
-        else:
-            file_exists = True
-            db_type = dbm.whichdb(files_db)
-            # Opening a db format not linked into CPython at build time will result in "".
-            if not "dbm" in db_type:
-                db_type = "unknown"
-            if os.access(files_db, os.W_OK):
-                can_write = True
-                # we need dbm.gnu here for success
-                if db_type != "dbm.gnu":
-                    if verbose:
-                        ctx.ui.info(_("FilesDB %s is writable, but is of wrong type '%s'.") % (files_db, db_type))
-                    flag = "n"
-                    needs_rebuild = True
-                else:
-                    flag = "w"
-                    # db_type is dbm.gnu and the backing file looks to be writable
-                    # So far, so good
-            elif os.access(files_db, os.R_OK):
-                can_write = False
-                # we need dbm.gnu here for success
-                if db_type != "dbm.gnu":
-                    if verbose:
-                        ctx.ui.info(_("FilesDB %s is readable, but is of wrong type '%s'.") % (files_db, db_type))
-                    please_rebuild_manually = True
-                else:
-                    if verbose:
-                        ctx.ui.info(_("Cannot open FilesDB %s for writing. Opening it read-only.") % files_db)
-                    flag = "r"
-                    # db_type is dbm.gnu and the backing file looks to be readable.
-                # This block falls back to simple XML search if FilesDB is not the correct format
-            else:
-                can_write = False
-                # the file exists, but we can neither read nor write to it
-                if verbose:
-                    ctx.ui.warning(_("FilesDB %s of type '%s' exists, but we cannot access it.") % (files_db, db_type))
-                please_rebuild_manually = True
-                # This block falls back to simple search because FilesDB isn't available
-
-        # At this point, we have checked the first three indentation levels of the
-        # decision tree. This means we need to try to open the shelve.
-
-        if flag is not None:
-            # At this point, we _should_ be able to _open_ the file.
-            try:
-                self.filesdb = shelve.open(files_db, flag, protocol=FILESDB_PICKLE_PROTOCOL_VERSION)
-                valid_shelve = True
-            except:
-                if verbose:
-                    ctx.ui.debug("shelve.open(files_db=%s, flag=%s, protocol=%s) failed."
-                                % (files_db, flag, FILESDB_PICKLE_PROTOCOL_VERSION))
-                valid_shelve = False
-                # Can't open the shelve, it needs a rebuild
-                msg = _("FilesDB %s is not in a valid shelve format.") % files_db
-                if can_write:
-                    if verbose:
-                        ctx.ui.info(msg)
-                    needs_rebuild = True
-                else:
-                    if verbose:
-                        ctx.ui.warning(msg)
-                    please_rebuild_manually = True
-                    # This falls back to simple XML search if FilesDB isn't valid
-
-            # If the backing shelve exists and is valid, check if it has a version key
-            if valid_shelve and file_exists:
+        if not force_rebuild:
+            if os.path.exists(files_db):
                 try:
-                    version = self.filesdb["version"]
-                except:
-                    msg = _("FilesDB %s has no version.") % files_db
-                    if can_write:
+                    # Try opening read-write first
+                    try:
+                        self.filesdb = shelve.open(
+                            files_db, "w", protocol=FILESDB_PICKLE_PROTOCOL_VERSION
+                        )
+                    except (dbm.error, PermissionError):
+                        # Fallback to read-only
+                        self.filesdb = shelve.open(
+                            files_db, "r", protocol=FILESDB_PICKLE_PROTOCOL_VERSION
+                        )
                         if verbose:
-                            ctx.ui.info(msg)
+                            ctx.ui.info(_("Opened FilesDB %s read-only.") % files_db)
+
+                    # Check version
+                    if self.filesdb.get("version") != FILESDB_FORMAT_VERSION:
+                        if verbose:
+                            ctx.ui.info(
+                                _("FilesDB version mismatch or missing version.")
+                            )
                         needs_rebuild = True
-                    else:
-                        if verbose:
-                           ctx.ui.warning(msg)
-                        please_rebuild_manually = True
-                        # This falls back to simple XML search if FilesDB is unversioned
 
-                if version is not None:
-                    if version != FILESDB_FORMAT_VERSION:
-                        msg = _("FilesDB is version %s, need version %s.") % (version, FILESDB_FORMAT_VERSION)
-                        if can_write:
-                            if verbose:
-                                ctx.ui.info(msg)
-                            needs_rebuild = True
-                        else:
-                            if verbose:
-                                ctx.ui.warning(msg)
-                            please_rebuild_manually = True
-                            # This falls back to simple XML search if FilesDB has the wrong version
+                except Exception as e:
+                    if verbose:
+                        ctx.ui.debug(f"Failed to open FilesDB {files_db}: {e}")
+                    needs_rebuild = True
+            else:
+                # File missing
+                needs_rebuild = True
 
-                    else:
-                        # Everything is ok, the shelve is open with flag = "w"
-                        needs_rebuild = False
-
-        ctx.ui.debug("FilesDB %s check result:" % files_db)
-        ctx.ui.debug("> file_exists = %s" % file_exists)
-        ctx.ui.debug("> can_write = %s" % can_write)
-        ctx.ui.debug("> db_type = %s" % db_type)
-        ctx.ui.debug("> flag = %s" % flag)
-        ctx.ui.debug("> valid_shelve = %s" % valid_shelve)
-        ctx.ui.debug("> version = %s" % version)
-        ctx.ui.debug("=> force_rebuild = %s" % force_rebuild)
-        ctx.ui.debug("=> needs_rebuild = %s" % needs_rebuild)
-        ctx.ui.debug("=> please_rebuild_manually = %s" % please_rebuild_manually)
-
-        # This block implies that the state is invalid
-        if please_rebuild_manually:
-            ctx.ui.warning(_("FilesDB is invalid. Please rebuild it with 'sudo eopkg.py -y rdb'"))
-            ctx.ui.warning(_("Falling back to slow and inaccurate XML search..."))
-
-        if force_rebuild or needs_rebuild:
-            self.__rebuild()
+        if needs_rebuild:
+            # Check if we have write access to the directory to perform a rebuild
+            if os.access(os.path.dirname(files_db) or ".", os.W_OK):
+                self.__rebuild()
+            else:
+                ctx.ui.warning(
+                    _("FilesDB is invalid and cannot be rebuilt (no write access).")
+                )
+                ctx.ui.warning(_("Falling back to slow and inaccurate XML search..."))
 
     def __rebuild(self):
-        # This assumes that __check_db() has run
+        # This assumes that __check_filesdb() has determined a rebuild is needed
         files_db = os.path.join(ctx.config.info_dir(), ctx.const.files_db)
         ctx.ui.info(_("Rebuilding the FilesDB..."))
+
         self.close()
         self.destroy()
         self.filesdb = {}
 
         try:
             # "n" means we're opening a new shelve, overwriting the old one
-            self.filesdb = shelve.open(files_db, "n", protocol=FILESDB_PICKLE_PROTOCOL_VERSION)
+            self.filesdb = shelve.open(
+                files_db, "n", protocol=FILESDB_PICKLE_PROTOCOL_VERSION
+            )
         except Exception as err:
-            ctx.ui.debug("shelve.open(files_db=%s, flag=%s, protocol=%s) failed."
-                           % (files_db, flag, FILESDB_PICKLE_PROTOCOL_VERSION))
-            ctx.ui.error(_("FilesDB rebuild failed!"))
+            ctx.ui.error(_("FilesDB rebuild failed: %s") % err)
             raise err
 
         self.filesdb["version"] = FILESDB_FORMAT_VERSION
@@ -341,76 +205,17 @@ class FilesDB(lazydb.LazyDB):
                     ctx.ui.info("-------------")
                 else:
                     ctx.ui.info(".", noln=True)
-        ctx.ui.info(ngettext("\n%(num)d package added in total.", "\n%(num)d packages added in total.", pkgs) % {"num": pkgs})
+        ctx.ui.info(
+            ngettext(
+                "\n%(num)d package added in total.",
+                "\n%(num)d packages added in total.",
+                pkgs,
+            )
+            % {"num": pkgs}
+        )
         # ensure that the changes get pushed out to disk
         self.filesdb.sync()
         # This acts as a check that the version has been correctly added and synced to disk
-        ctx.ui.info(_("Done rebuilding FilesDB (version: %s)") % self.filesdb["version"])
-
-    def __check_filesdb_old(self):
-        """Sets valid self.files_db reference and returns whether the underlying db needs to be rebuilt."""
-        # whether or not we need to rebuild the FilesDB
-        needs_rebuild = False
-
-        if isinstance(self.filesdb, shelve.DbfilenameShelf):
-            # the db has already been correctly initialised
-            return needs_rebuild
-
-        # We don't know the db type by default
-        db_type = "?"
-
-        files_db = os.path.join(ctx.config.info_dir(), ctx.const.files_db)
-
-        if os.path.exists(files_db):
-            # check the kind of db
-            db_type = dbm.whichdb(files_db)
-            if db_type != "dbm.gnu":
-                if not os.access(files_db, os.W_OK):
-                    ctx.ui.debug("Cannot write to type %s database cache %s, ignoring." % (db_type, files_db))
-                    return needs_rebuild
-                else:
-                    ctx.ui.debug("Incompatible type %s database cache %s found, needs_rebuild = True" % (db_type, files_db))
-                    needs_rebuild = True
-
-        if not os.path.exists(files_db):
-            flag = "n"
-            ctx.ui.debug("No database cache %s found, needs_rebuild = True" % (files_db))
-            needs_rebuild = True
-        elif os.access(files_db, os.W_OK):
-            flag = "w"
-        else:
-            flag = "r"
-            ctx.ui.debug("Type %s database cache %s is read-only." % (db_type, files_db))
-
-        # At this point, we _should_ be able to _open_ the file.
-        # The only remaining question is whether the pickle protocol version is correct
-        try:
-            # NOTE: This will use gdbm format db files by default
-            self.filesdb = shelve.open(files_db, flag, protocol=FILESDB_PICKLE_PROTOCOL_VERSION)
-        except:
-             ctx.ui.debug("shelve.open(files_db=%s, flag=%s, protocol=%s) failed, needs_rebuild = True"
-                           % (files_db, flag, FILESDB_PICKLE_PROTOCOL_VERSION))
-             needs_rebuild = True
-             return needs_rebuild
-
-        # Check if self.filesdb has a version key
-        has_version = True
-        version = 0
-        try:
-            version = self.filesdb["version"]
-        except:
-            has_version = False
-
-        # At this point, either:
-        #  has_version is True and version != 0,
-        #   XOR
-        #  has_version is False and version == 0
-
-        if flag != "r":
-            if not has_version or version != FILESDB_FORMAT_VERSION:
-                ctx.ui.debug("Incompatible type %s database cache %s found (version: (%s, %s), expected (%s, %s)), needs_rebuild = True" % (db_type, files_db, has_version, version, True, FILESDB_FORMAT_VERSION))
-                needs_rebuild = True
-
-        # False unless the logic above caused it to be toggled to True
-        return needs_rebuild
-
+        ctx.ui.info(
+            _("Done rebuilding FilesDB (version: %s)") % self.filesdb["version"]
+        )


### PR DESCRIPTION
## Summary

    db/filesdb: Refactor for try except workflow

    Currently, the existing checks are overengineered and assumptions
    were broken when the default python shelve type was changed in python
    3.13.

    Let's refactor to a more simplified try except workflow allowing shelve
    itself to manage defaults (EAFP) rather than using an overly
    pre-defensive workflow.

    db/filesdb: Default to gbm.gnu shelve if available

    Writing to a sqlite DB is significantly slower than gdbm, as we
    literally just use the shelve as a fast filepath lookup for file
    conflicts handling we don't need the full power of a sqlite DB.

## Test Plan

`eopkg rdb`
Ensure that an sqlite shelve gets rebuilt for gdbm
`eopkg sf /usr/bin/nano`
Ensure the previous rebuilding logic works as before
Dogfooding in unstable