### PR TITLE
Venv annoyingness

### DIFF
--- a/eopkg_venv_functions.bash
+++ b/eopkg_venv_functions.bash
@@ -21,15 +21,6 @@ function prepare_venv () {
 
     printInfo "Symlink eopkg-cli into the eopkg_venv bin/ directory so it can be executed as eopkg.py ..."
     ln -srvf ./eopkg-cli eopkg_venv/bin/eopkg.py
-
-    # get rid of any existing lines w/git ref version info
-    sed "/__version__ += /d" -i pisi/__init__.py
-    printInfo "pisi version variable BEFORE patching:":
-    grep -Hn version pisi/__init__.py
-    # append the git ref to __version__ on a new line
-    gawk -i inplace 'BEGIN { "git rev-parse --short HEAD" | getline gitref } { print }; /__version__ = / { printf "%s %s\n", $1, "+= \" (" gitref ")\"" }' pisi/__init__.py
-    printInfo "pisi version variable AFTER patching w/git revision:"
-    grep -Hn version pisi/__init__.py
 }
 
 function compile_iksemel_cleanly () {

--- a/eopkg_venv_functions.bash
+++ b/eopkg_venv_functions.bash
@@ -6,19 +6,12 @@ set -euo pipefail
 
 source shared_functions.bash
 
-# allow user to override branch name
-EOPKG_BRANCH="${BRANCH:-main}"
-
 function prepare_venv () {
     if [[ -z "${PY3}" ]]; then
         die "Couldn't find supported python3 (3.11 || 3.12 || 3.10) interpreter, exiting!"
     else
         printInfo "Using python3 interpreter: ${PY3}"
     fi
-    # Assume the user starts in the eopkg dir
-    printInfo "Updating the eopkg git repo ..."
-    # ensure we show the current branch
-    git fetch && git checkout "${EOPKG_BRANCH}" && git pull && git branch
 
     printInfo "Set up a clean eopkg_venv venv ..."
     ${PY3} -m venv --system-site-packages --clear eopkg_venv


### PR DESCRIPTION
## Summary

Fix some annoying venv issues
- When resetting stale venvs it auto switches the branch to main causing headaches
- Adding in the commit to version causes pickle cache invalidation issues where you would update a package, switch branch, and the package would show up as being needing to update again.

## Test Plan

Setup fresh venv