### PR TITLE
db/packagedb: Fix minor zlib import issue

### DIFF
--- a/pisi/db/packagedb.py
+++ b/pisi/db/packagedb.py
@@ -5,11 +5,10 @@
 #
 
 import datetime
-import gettext
-import gzip
 import os
 import re
 import time
+import zlib
 
 import iksemel
 
@@ -69,7 +68,7 @@ class PackageDB(lazydb.LazyDB):
     def __generate_packages(self, doc):
         return dict(
             [
-                (x.getTagData("Name"), gzip.zlib.compress(x.toString().encode()))
+                (x.getTagData("Name"), zlib.compress(x.toString().encode()))
                 for x in doc.tags("Package")
             ]
         )


### PR DESCRIPTION
## Summary

Import zlib directly, no need to go via gzip

Also remove unused import

## Test Plan

Use ./eopkg.py ur --force to hit the `__generate_packages` path, then use a few common operations to ensure everything was normal.